### PR TITLE
Handle missing documents and persist uploads

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -2,10 +2,10 @@
 from collections.abc import Iterable
 from uuid import UUID
 
-from fastapi import APIRouter, UploadFile
+from fastapi import APIRouter, HTTPException, UploadFile
 
-from ...models.documents import DocumentCreateResponse, DocumentMetadata, DocumentProcessingStatus
-from ...services.pipeline import DocumentPipeline
+from ...models.documents import DocumentCreateResponse, DocumentMetadata
+from ...services.pipeline import DocumentNotFoundError, DocumentPipeline
 
 router = APIRouter()
 
@@ -28,11 +28,17 @@ async def list_documents() -> Iterable[DocumentMetadata]:
 @router.get("/{document_id}", summary="Get metadata for a document", response_model=DocumentMetadata)
 async def get_document(document_id: UUID) -> DocumentMetadata:
     """Fetch stored metadata for an individual document."""
-    return pipeline.metadata_store.get_document(document_id)
+    try:
+        return pipeline.metadata_store.get_document(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
 
 
 @router.get("/{document_id}/qa", summary="Ask a question about a document")
 async def ask_question(document_id: UUID, question: str) -> dict[str, str]:
     """Provide a lightweight placeholder for document Q&A functionality."""
-    answer = await pipeline.answer_question(document_id=document_id, question=question)
+    try:
+        answer = await pipeline.answer_question(document_id=document_id, question=question)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
     return {"answer": answer}

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable
 from uuid import UUID
 
 from fastapi import UploadFile
 
+from ..core.config import get_settings
 from ..models.documents import DocumentMetadata, DocumentProcessingStatus
+
+
+class DocumentNotFoundError(KeyError):
+    """Raised when requested document metadata is not present in the store."""
+
+    def __init__(self, document_id: UUID) -> None:
+        message = f"Document with id {document_id} was not found"
+        super().__init__(message)
+        self.document_id = document_id
 
 
 @dataclass
@@ -24,7 +35,10 @@ class MetadataStore:
         self._documents[document.document_id] = document
 
     def get_document(self, document_id: UUID) -> DocumentMetadata:
-        return self._documents[document_id]
+        try:
+            return self._documents[document_id]
+        except KeyError as exc:
+            raise DocumentNotFoundError(document_id) from exc
 
     def list_documents(self) -> list[DocumentMetadata]:
         return list(self._documents.values())
@@ -35,14 +49,16 @@ class DocumentPipeline:
 
     def __init__(self) -> None:
         self.metadata_store = MetadataStore()
+        self._settings = get_settings()
 
     async def ingest(self, file: UploadFile) -> DocumentMetadata:
         metadata = DocumentMetadata(title=file.filename or "unknown")
+        await self._persist_upload(file, metadata)
         self.metadata_store.add_document(metadata)
-        asyncio.create_task(self._run_pipeline(metadata, file))
+        asyncio.create_task(self._run_pipeline(metadata))
         return metadata
 
-    async def _run_pipeline(self, metadata: DocumentMetadata, file: UploadFile) -> None:
+    async def _run_pipeline(self, metadata: DocumentMetadata) -> None:
         try:
             metadata.status = DocumentProcessingStatus.PROCESSING
             await asyncio.sleep(0)  # placeholder for heavy work
@@ -63,3 +79,15 @@ class DocumentPipeline:
 
     def iter_documents(self) -> Iterable[DocumentMetadata]:
         return self.metadata_store.list_documents()
+
+    async def _persist_upload(self, file: UploadFile, metadata: DocumentMetadata) -> None:
+        """Store the incoming file on disk so background tasks can access it."""
+
+        filename = Path(file.filename).name if file.filename else "document"
+        document_dir = self._settings.data_dir / str(metadata.document_id) / "raw"
+        document_dir.mkdir(parents=True, exist_ok=True)
+        destination = document_dir / filename
+        content = await file.read()
+        destination.write_bytes(content)
+        metadata.source_path = destination
+        await file.close()

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,0 +1,64 @@
+"""Integration tests for document API endpoints."""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client_and_modules(tmp_path, monkeypatch):
+    """Provide a configured TestClient and access to the documents module."""
+
+    monkeypatch.setenv("PROSTE_PRAWO_DATA_DIR", str(tmp_path))
+    from app.core import config
+
+    config.get_settings.cache_clear()
+    documents_module = importlib.reload(importlib.import_module("app.api.routes.documents"))
+    main_module = importlib.reload(importlib.import_module("app.main"))
+    test_client = TestClient(main_module.app)
+    try:
+        yield test_client, documents_module
+    finally:
+        test_client.close()
+        config.get_settings.cache_clear()
+
+
+def test_get_document_missing_returns_404(client_and_modules):
+    client, _ = client_and_modules
+    missing_id = uuid4()
+
+    response = client.get(f"/documents/{missing_id}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Document not found"
+
+
+def test_upload_persists_file(client_and_modules):
+    client, documents_module = client_and_modules
+    payload = b"Postanowienia umowne"
+    filename = "umowa.txt"
+
+    response = client.post("/documents/", files={"file": (filename, payload, "text/plain")})
+
+    assert response.status_code == 200
+    data = response.json()
+    document_id = UUID(data["document_id"])
+
+    from app.core.config import get_settings
+
+    metadata = documents_module.pipeline.metadata_store.get_document(document_id)
+    assert metadata.source_path is not None
+    assert metadata.source_path.exists()
+    assert metadata.source_path.read_bytes() == payload
+    assert metadata.source_path.name == filename
+
+    settings = get_settings()
+    assert Path(settings.data_dir) in metadata.source_path.parents
+    assert metadata.source_path.parent.name == "raw"
+    assert metadata.source_path.parent.parent.name == str(document_id)


### PR DESCRIPTION
## Summary
- ensure the document metadata store raises a domain error and map missing resources to HTTP 404 responses
- persist uploaded files to disk before background processing and record the source path on metadata
- add integration tests that cover 404 handling and upload persistence (skipped if FastAPI is unavailable)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb9b2927083268f823e6b0a36292d