### PR TITLE
Fix SimpleIndexer term statistics isolation

### DIFF
--- a/backend/app/services/indexing.py
+++ b/backend/app/services/indexing.py
@@ -24,7 +24,7 @@ class SimpleIndexer:
 
     def __init__(self) -> None:
         self._documents: dict[UUID, list[DocumentSection]] = {}
-        self._term_stats: dict[str, Counter[str]] = {}
+        self._term_stats: dict[str, Counter[tuple[UUID, str]]] = {}
 
     def index(self, document_id: UUID, sections: Iterable[DocumentSection]) -> None:
         sections = list(sections)
@@ -32,24 +32,30 @@ class SimpleIndexer:
         for section in sections:
             term_counts = Counter(_tokenize(section.text))
             for term, count in term_counts.items():
-                self._term_stats.setdefault(term, Counter())[section.identifier] = count
+                key = (document_id, section.identifier)
+                self._term_stats.setdefault(term, Counter())[key] = count
 
     def retrieve(self, document_id: UUID, query: str, top_k: int = 3) -> list[RetrievedChunk]:
         sections = self._documents.get(document_id, [])
         if not sections:
             return []
         query_terms = Counter(_tokenize(query))
+        section_by_id = {section.identifier: section for section in sections}
         scores: dict[str, float] = {}
         for term, q_freq in query_terms.items():
             postings = self._term_stats.get(term)
             if not postings:
                 continue
-            idf = math.log(1 + len(self._documents) / (1 + len(postings)))
-            for identifier, freq in postings.items():
+            doc_freq = len({doc_id for doc_id, _ in postings})
+            idf = math.log(1 + len(self._documents) / (1 + doc_freq))
+            for (posting_doc_id, identifier), freq in postings.items():
+                if posting_doc_id != document_id:
+                    continue
+                if identifier not in section_by_id:
+                    continue
                 scores.setdefault(identifier, 0.0)
                 scores[identifier] += (1 + math.log(freq)) * idf * q_freq
         ranked = sorted(scores.items(), key=lambda item: item[1], reverse=True)[:top_k]
-        section_by_id = {section.identifier: section for section in sections}
         results: list[RetrievedChunk] = []
         for identifier, score in ranked:
             section = section_by_id.get(identifier)

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -122,3 +122,46 @@ def test_repository_survives_restart(client_and_modules):
 
     answer = asyncio.run(new_pipeline.answer_question(document_id, "Jakie są obowiązki stron?"))
     assert "obowiąz" in answer.lower()
+
+
+def test_indexing_is_isolated_between_documents(client_and_modules):
+    client, _ = client_and_modules
+
+    alpha_payload = (
+        "Dokument Alfa.\n"
+        "Art. 1. Szczegóły dotyczą wyłącznie procedury Alfa."
+    ).encode("utf-8")
+    beta_payload = (
+        "Dokument Beta.\n"
+        "Art. 1. Niniejszy opis skupia się na zadaniach Beta."
+    ).encode("utf-8")
+
+    alpha_response = client.post(
+        "/documents/",
+        files={"file": ("alpha.txt", alpha_payload, "text/plain")},
+    )
+    beta_response = client.post(
+        "/documents/",
+        files={"file": ("beta.txt", beta_payload, "text/plain")},
+    )
+
+    alpha_id = UUID(alpha_response.json()["document_id"])
+    beta_id = UUID(beta_response.json()["document_id"])
+
+    _wait_for_status(client, alpha_id, "ready")
+    _wait_for_status(client, beta_id, "ready")
+
+    alpha_answer = client.get(
+        f"/documents/{alpha_id}/qa",
+        params={"question": "Czego dotyczy procedura Alfa?"},
+    ).json()["answer"]
+    beta_answer = client.get(
+        f"/documents/{beta_id}/qa",
+        params={"question": "Czego dotyczy zadanie Beta?"},
+    ).json()["answer"]
+
+    assert "Źródła" in alpha_answer
+    assert "Źródła" in beta_answer
+    assert "Alfa" in alpha_answer
+    assert "Beta" in beta_answer
+    assert "Alfa" not in beta_answer


### PR DESCRIPTION
## Summary
- ensure term statistics keys include the document id so postings do not clash across documents
- filter retrieval scoring to sections belonging to the requested document
- add an integration test covering multi-document indexing isolation

## Testing
- pytest backend/tests/test_documents.py -k indexing_is_isolated_between_documents

------
https://chatgpt.com/codex/tasks/task_e_68ddc0ae23c083268cba79ab9c0bf183