### PR TITLE
Add PDF downloads for processed documents

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 
 from ...models.documents import DocumentCreateResponse, DocumentMetadata
 from ...services.pipeline import DocumentNotFoundError, DocumentPipeline
@@ -42,3 +43,25 @@ async def ask_question(document_id: UUID, question: str) -> dict[str, str]:
     except DocumentNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Document not found") from exc
     return {"answer": answer}
+
+
+@router.get("/{document_id}/student-book", summary="Download the student PDF")
+async def download_student_book(document_id: UUID) -> FileResponse:
+    try:
+        path = pipeline.get_student_book(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FileResponse(path, media_type="application/pdf", filename=path.name)
+
+
+@router.get("/{document_id}/teacher-book", summary="Download the teacher PDF")
+async def download_teacher_book(document_id: UUID) -> FileResponse:
+    try:
+        path = pipeline.get_teacher_book(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FileResponse(path, media_type="application/pdf", filename=path.name)

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -28,6 +28,8 @@ class DocumentMetadata(BaseModel):
     status: DocumentProcessingStatus = DocumentProcessingStatus.RECEIVED
     source_path: Path | None = None
     sanitized_path: Path | None = None
+    student_book_pdf: Path | None = None
+    teacher_book_pdf: Path | None = None
     summary: str | None = None
     obligations: list[str] = Field(default_factory=list)
     penalties: list[str] = Field(default_factory=list)

--- a/backend/app/repositories/documents.py
+++ b/backend/app/repositories/documents.py
@@ -67,7 +67,7 @@ def _serialize_document(document: DocumentMetadata) -> dict:
     data["document_id"] = str(document.document_id)
     data["created_at"] = document.created_at.isoformat()
     data["status"] = document.status.value
-    for path_key in ("source_path", "sanitized_path"):
+    for path_key in ("source_path", "sanitized_path", "student_book_pdf", "teacher_book_pdf"):
         value = data.get(path_key)
         if value is not None:
             data[path_key] = str(value)
@@ -79,7 +79,7 @@ def _deserialize_document(data: dict) -> DocumentMetadata:
     parsed["document_id"] = UUID(parsed["document_id"])
     parsed["created_at"] = datetime.fromisoformat(parsed["created_at"])
     parsed["status"] = DocumentProcessingStatus(parsed["status"])
-    for path_key in ("source_path", "sanitized_path"):
+    for path_key in ("source_path", "sanitized_path", "student_book_pdf", "teacher_book_pdf"):
         value = parsed.get(path_key)
         if value:
             parsed[path_key] = Path(value)

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -14,6 +14,63 @@ from ..repositories import DocumentRepository
 from . import inference, ingestion, indexing, sanitizer
 
 
+def _escape_pdf_text(text: str) -> str:
+    return (
+        text.replace("\\", r"\\\\").replace("(", r"\(").replace(")", r"\)")
+    )
+
+
+def _write_simple_pdf(destination: Path, title: str, body: str) -> None:
+    """Persist ``title`` and ``body`` into a lightweight PDF document."""
+
+    combined_parts = [part.strip() for part in (title or "", body or "") if part and part.strip()]
+    combined = "\n\n".join(combined_parts)
+    lines = combined.splitlines() if combined else [""]
+    stream_lines = ["BT", "/F1 12 Tf", "72 720 Td"]
+    for index, line in enumerate(lines):
+        escaped = _escape_pdf_text(line)
+        if index == 0:
+            stream_lines.append(f"({escaped}) Tj")
+        else:
+            stream_lines.append("T*")
+            stream_lines.append(f"({escaped}) Tj")
+    stream_lines.append("ET")
+    stream = "\n".join(stream_lines) + "\n"
+    stream_bytes = stream.encode("utf-8")
+
+    objects: list[bytes] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+        b"<< /Length "
+        + str(len(stream_bytes)).encode("utf-8")
+        + b" >>\nstream\n"
+        + stream_bytes
+        + b"endstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("wb") as handle:
+        handle.write(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+        offsets: list[int] = [0]
+        for index, obj in enumerate(objects, start=1):
+            offsets.append(handle.tell())
+            handle.write(f"{index} 0 obj\n".encode("utf-8"))
+            handle.write(obj)
+            handle.write(b"\nendobj\n")
+        xref_offset = handle.tell()
+        handle.write(f"xref\n0 {len(objects) + 1}\n".encode("utf-8"))
+        handle.write(b"0000000000 65535 f \n")
+        for offset in offsets[1:]:
+            handle.write(f"{offset:010d} 00000 n \n".encode("utf-8"))
+        handle.write(b"trailer\n")
+        handle.write(f"<< /Size {len(objects) + 1} /Root 1 0 R >>\n".encode("utf-8"))
+        handle.write(b"startxref\n")
+        handle.write(f"{xref_offset}\n".encode("utf-8"))
+        handle.write(b"%%EOF")
+
+
 class DocumentNotFoundError(KeyError):
     """Raised when requested document metadata is not present in the store."""
 
@@ -72,6 +129,34 @@ class DocumentPipeline:
             metadata.obligations = inference.extract_obligations(sanitized.text)
             metadata.penalties = inference.extract_penalties(sanitized.text)
             metadata.deadlines = inference.extract_deadlines(sanitized.text)
+
+            pdf_dir = self._settings.data_dir / str(document_id) / "pdf"
+            student_pdf_path = pdf_dir / "student_book.pdf"
+            teacher_pdf_path = pdf_dir / "teacher_book.pdf"
+
+            _write_simple_pdf(student_pdf_path, metadata.title, sanitized.text)
+
+            teacher_sections: list[str] = []
+            if metadata.summary:
+                teacher_sections.append(f"Podsumowanie:\n{metadata.summary}")
+            if metadata.obligations:
+                teacher_sections.append(
+                    "Obowiązki:\n" + "\n".join(metadata.obligations)
+                )
+            if metadata.penalties:
+                teacher_sections.append("Kary:\n" + "\n".join(metadata.penalties))
+            if metadata.deadlines:
+                teacher_sections.append("Terminy:\n" + "\n".join(metadata.deadlines))
+            teacher_sections.append(sanitized.text)
+
+            _write_simple_pdf(
+                teacher_pdf_path,
+                f"{metadata.title} (wersja nauczycielska)",
+                "\n\n".join(teacher_sections),
+            )
+
+            metadata.student_book_pdf = student_pdf_path
+            metadata.teacher_book_pdf = teacher_pdf_path
             metadata.status = DocumentProcessingStatus.READY
             self.repository.upsert(metadata)
         except Exception as exc:  # pragma: no cover - defensive path
@@ -96,6 +181,20 @@ class DocumentPipeline:
 
     def get_document(self, document_id: UUID) -> DocumentMetadata:
         return self._get(document_id)
+
+    def get_student_book(self, document_id: UUID) -> Path:
+        metadata = self._get(document_id)
+        path = metadata.student_book_pdf
+        if path and path.exists():
+            return path
+        raise FileNotFoundError("Student book PDF not available")
+
+    def get_teacher_book(self, document_id: UUID) -> Path:
+        metadata = self._get(document_id)
+        path = metadata.teacher_book_pdf
+        if path and path.exists():
+            return path
+        raise FileNotFoundError("Teacher book PDF not available")
 
     async def _persist_upload(self, file: UploadFile, metadata: DocumentMetadata) -> None:
         filename = Path(file.filename).name if file.filename else "document"

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -94,6 +94,16 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert any("kara" in item.lower() for item in data["penalties"])
     assert "EMAIL" in " ".join(data["pii_entities"].keys()).upper()
 
+    student_pdf = client.get(f"/documents/{document_id}/student-book")
+    assert student_pdf.status_code == 200
+    assert student_pdf.headers["content-type"].startswith("application/pdf")
+    assert student_pdf.content.startswith(b"%PDF")
+
+    teacher_pdf = client.get(f"/documents/{document_id}/teacher-book")
+    assert teacher_pdf.status_code == 200
+    assert teacher_pdf.headers["content-type"].startswith("application/pdf")
+    assert teacher_pdf.content.startswith(b"%PDF")
+
     qa_response = client.get(
         f"/documents/{document_id}/qa",
         params={"question": "Jaka kara grozi za naruszenie?"},
@@ -111,6 +121,8 @@ def test_repository_survives_restart(client_and_modules):
 
     metadata = documents_module.pipeline.get_document(document_id)
     assert metadata.sanitized_path and metadata.sanitized_path.exists()
+    assert metadata.student_book_pdf and metadata.student_book_pdf.exists()
+    assert metadata.teacher_book_pdf and metadata.teacher_book_pdf.exists()
 
     # Simulate application restart by creating a fresh pipeline instance
     from app.services.pipeline import DocumentPipeline


### PR DESCRIPTION
## Summary
- add persistent student and teacher PDF paths to stored document metadata
- generate lightweight student/teacher PDF artifacts during pipeline processing and record their locations
- expose download endpoints for the PDFs and extend tests to cover the new behavior

## Testing
- `pytest backend/tests/test_documents.py`


------
https://chatgpt.com/codex/tasks/task_e_68ddc3f1a9208326a69e3c39f73455f0