### PR TITLE
Protect PII metadata and fix section numbering

### DIFF
--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -32,7 +32,8 @@ class DocumentMetadata(BaseModel):
     obligations: list[str] = Field(default_factory=list)
     penalties: list[str] = Field(default_factory=list)
     deadlines: list[str] = Field(default_factory=list)
-    pii_entities: dict[str, list[str]] = Field(default_factory=dict)
+    pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
+    pii_secret_path: Path | None = None
     extra: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/backend/app/repositories/documents.py
+++ b/backend/app/repositories/documents.py
@@ -67,7 +67,7 @@ def _serialize_document(document: DocumentMetadata) -> dict:
     data["document_id"] = str(document.document_id)
     data["created_at"] = document.created_at.isoformat()
     data["status"] = document.status.value
-    for path_key in ("source_path", "sanitized_path"):
+    for path_key in ("source_path", "sanitized_path", "pii_secret_path"):
         value = data.get(path_key)
         if value is not None:
             data[path_key] = str(value)
@@ -79,7 +79,7 @@ def _deserialize_document(data: dict) -> DocumentMetadata:
     parsed["document_id"] = UUID(parsed["document_id"])
     parsed["created_at"] = datetime.fromisoformat(parsed["created_at"])
     parsed["status"] = DocumentProcessingStatus(parsed["status"])
-    for path_key in ("source_path", "sanitized_path"):
+    for path_key in ("source_path", "sanitized_path", "pii_secret_path"):
         value = parsed.get(path_key)
         if value:
             parsed[path_key] = Path(value)

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -68,8 +68,20 @@ def _read_text(path: Path) -> str:
 
 def _split_into_sections(text: str) -> Iterable[DocumentSection]:
     buffer = io.StringIO()
-    current_identifier = "section-1"
-    index = 1
+    current_label: str | None = None
+    emitted = 0
+
+    def emit_section(content: str, label: str | None) -> Iterable[DocumentSection]:
+        nonlocal emitted
+        stripped = content.strip()
+        if not stripped:
+            return []
+        emitted += 1
+        identifier = f"section-{emitted}"
+        if label:
+            identifier = f"{identifier}: {label}"
+        return [DocumentSection(identifier=identifier, text=stripped)]
+
     for line in text.splitlines():
         line = line.rstrip()
         if not line:
@@ -77,12 +89,21 @@ def _split_into_sections(text: str) -> Iterable[DocumentSection]:
             continue
         match = _SECTION_PATTERN.match(line)
         if match:
-            if buffer.tell() > 0:
-                yield DocumentSection(identifier=current_identifier, text=buffer.getvalue().strip())
+            content = buffer.getvalue()
+            if content and (emitted > 0 or current_label is not None):
+                for section in emit_section(content, current_label):
+                    yield section
                 buffer = io.StringIO()
-            index += 1
-            current_identifier = f"section-{index}: {match.group().strip()}"
+            elif content:
+                # Preserve leading preambles inside the first labelled section.
+                buffer = io.StringIO()
+                buffer.write(content)
+            else:
+                buffer = io.StringIO()
+            current_label = match.group().strip()
         buffer.write(line)
         buffer.write("\n")
-    if buffer.tell() > 0:
-        yield DocumentSection(identifier=current_identifier, text=buffer.getvalue().strip())
+    content = buffer.getvalue()
+    if content:
+        for section in emit_section(content, current_label):
+            yield section

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Iterable
 from pathlib import Path
 from uuid import UUID
@@ -60,8 +61,17 @@ class DocumentPipeline:
             sanitized_path = sanitized_dir / "document.txt"
             sanitized_path.write_text(sanitized.text, encoding="utf-8")
 
+            secure_dir = self._settings.data_dir / str(document_id) / "secure"
+            secure_dir.mkdir(parents=True, exist_ok=True)
+            secrets_path = secure_dir / "pii_map.json"
+            secrets_path.write_text(
+                json.dumps(sanitized.secrets, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
             metadata.sanitized_path = sanitized_path
-            metadata.pii_entities = sanitized.entities
+            metadata.pii_placeholders = sanitized.entities
+            metadata.pii_secret_path = secrets_path
 
             sanitized_sections = await asyncio.to_thread(
                 lambda: ingestion.extract_document(sanitized_path).sections

--- a/backend/app/services/sanitizer.py
+++ b/backend/app/services/sanitizer.py
@@ -23,6 +23,7 @@ class SanitizationResult:
 
     text: str
     entities: dict[str, list[str]]
+    secrets: dict[str, dict[str, str]]
 
 
 def sanitize_text(text: str) -> SanitizationResult:
@@ -35,6 +36,7 @@ def sanitize_text(text: str) -> SanitizationResult:
     """
 
     entities: dict[str, list[str]] = defaultdict(list)
+    secrets: dict[str, dict[str, str]] = defaultdict(dict)
     sanitized = text
     for entity, pattern in PII_PATTERNS.items():
         counter = 0
@@ -43,6 +45,7 @@ def sanitize_text(text: str) -> SanitizationResult:
             counter += 1
             placeholder = f"<{entity.upper()}_{counter}>"
             value = match.group(0)
-            entities[entity].append(value)
+            entities[entity].append(placeholder)
+            secrets[entity][placeholder] = value
             sanitized = sanitized.replace(value, placeholder, 1)
-    return SanitizationResult(text=sanitized, entities=dict(entities))
+    return SanitizationResult(text=sanitized, entities=dict(entities), secrets=dict(secrets))

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 import time
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -92,7 +93,26 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert data["summary"] is not None
     assert any("termin" in item.lower() for item in data["deadlines"])
     assert any("kara" in item.lower() for item in data["penalties"])
-    assert "EMAIL" in " ".join(data["pii_entities"].keys()).upper()
+    assert "pii_placeholders" in data
+    assert "email" in data["pii_placeholders"]
+    assert all("<" in value and ">" in value for value in data["pii_placeholders"]["email"])
+    serialized = json.dumps(data)
+    assert "biuro@example.com" not in serialized
+
+    from sqlite3 import connect
+
+    with connect(Path(data["pii_secret_path"]).parents[2] / "metadata.db") as conn:
+        row = conn.execute(
+            "SELECT payload FROM documents WHERE document_id = ?",
+            (str(document_id),),
+        ).fetchone()
+        assert row is not None
+        assert "biuro@example.com" not in row[0]
+
+    secret_path = Path(data["pii_secret_path"])
+    assert secret_path.exists()
+    secrets_payload = secret_path.read_text(encoding="utf-8")
+    assert "biuro@example.com" in secrets_payload
 
     qa_response = client.get(
         f"/documents/{document_id}/qa",

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -1,0 +1,111 @@
+"""Unit tests for ingestion structure and sanitisation privacy guarantees."""
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_section_numbering_starts_at_one(tmp_path):
+    from app.services import ingestion
+
+    content = (
+        "Art. 1. Pierwszy artykuł.\n"
+        "Art. 2. Drugi artykuł."
+    )
+    path = tmp_path / "ustawa.txt"
+    path.write_text(content, encoding="utf-8")
+
+    extracted = ingestion.extract_document(path)
+
+    assert extracted.sections[0].identifier.startswith("section-1")
+    assert ": Art. 1" in extracted.sections[0].identifier
+    assert extracted.sections[1].identifier.startswith("section-2")
+
+
+def test_section_numbering_with_preamble(tmp_path):
+    from app.services import ingestion
+
+    content = (
+        "Preambuła dokumentu.\n"
+        "Art. 1. Postanowienia ogólne.\n"
+        "Art. 2. Postanowienia końcowe."
+    )
+    path = tmp_path / "statut.txt"
+    path.write_text(content, encoding="utf-8")
+
+    extracted = ingestion.extract_document(path)
+
+    assert extracted.sections[0].identifier.startswith("section-1")
+    assert ": Art. 1" in extracted.sections[0].identifier
+    assert "Preambuła" in extracted.sections[0].text
+    assert extracted.sections[1].identifier.startswith("section-2")
+
+
+def test_pipeline_persists_only_placeholders(tmp_path, monkeypatch):
+    pytest.importorskip("pydantic")
+    monkeypatch.setenv("PROSTE_PRAWO_DATA_DIR", str(tmp_path))
+    from app.core import config
+    from app.models.documents import DocumentMetadata
+    from app.services.pipeline import DocumentPipeline
+
+    config.get_settings.cache_clear()
+    try:
+        pipeline = DocumentPipeline()
+
+        metadata = DocumentMetadata(title="regulamin.txt")
+        document_dir = tmp_path / str(metadata.document_id) / "raw"
+        document_dir.mkdir(parents=True, exist_ok=True)
+        payload = (
+            "Art. 1. Termin dostarczenia wynosi 7 dni.\n"
+            "Kontakt: biuro@example.com.\n"
+            "PESEL: 12345678901."
+        )
+        source_path = document_dir / "regulamin.txt"
+        source_path.write_text(payload, encoding="utf-8")
+        metadata.source_path = source_path
+
+        pipeline.repository.upsert(metadata)
+        asyncio.run(pipeline._run_pipeline(metadata.document_id))
+
+        processed = pipeline.get_document(metadata.document_id)
+
+        assert processed.pii_placeholders["email"] == ["<EMAIL_1>"]
+        assert processed.pii_placeholders["pesel"] == ["<PESEL_1>"]
+        assert "biuro@example.com" not in processed.summary
+
+        sanitized_text = processed.sanitized_path.read_text(encoding="utf-8")
+        assert "biuro@example.com" not in sanitized_text
+        assert "12345678901" not in sanitized_text
+        assert "<EMAIL_1>" in sanitized_text
+        assert "<PESEL_1>" in sanitized_text
+
+        metadata_db = tmp_path / "metadata.db"
+        with sqlite3.connect(metadata_db) as conn:
+            row = conn.execute(
+                "SELECT payload FROM documents WHERE document_id = ?",
+                (str(processed.document_id),),
+            ).fetchone()
+            assert row is not None
+            payload_json = row[0]
+        assert "biuro@example.com" not in payload_json
+        assert "12345678901" not in payload_json
+
+        secrets_path = Path(processed.pii_secret_path)
+        secrets_content = secrets_path.read_text(encoding="utf-8")
+        assert "biuro@example.com" in secrets_content
+        assert "12345678901" in secrets_content
+        placeholders = json.loads(secrets_content)
+        assert placeholders["email"]["<EMAIL_1>"] == "biuro@example.com"
+        assert placeholders["pesel"]["<PESEL_1>"] == "12345678901"
+    finally:
+        config.get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- ensure the sanitizer surfaces only placeholder identifiers while persisting the raw mapping under /data/<docId>/secure
- extend document metadata and the SQLite repository to expose sanitized placeholders plus a secure artefact reference, updating the pipeline accordingly
- fix section numbering so the first Art./§ chunk is labelled section-1 and add regression tests for numbering and metadata privacy

## Testing
- pytest backend/tests/test_ingestion.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc171dae4832696e48cd6dd9ffeee