### PR TITLE
Hide server file paths from document metadata responses

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -4,7 +4,11 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, UploadFile
 
-from ...models.documents import DocumentCreateResponse, DocumentMetadata
+from ...models.documents import (
+    DocumentCreateResponse,
+    DocumentMetadata,
+    DocumentMetadataPublic,
+)
 from ...services.pipeline import DocumentNotFoundError, DocumentPipeline
 
 router = APIRouter()
@@ -19,19 +23,28 @@ async def upload_document(file: UploadFile) -> DocumentCreateResponse:
     return DocumentCreateResponse(document_id=document.document_id, status=document.status)
 
 
-@router.get("/", summary="List processed documents", response_model=list[DocumentMetadata])
-async def list_documents() -> Iterable[DocumentMetadata]:
+@router.get(
+    "/",
+    summary="List processed documents",
+    response_model=list[DocumentMetadataPublic],
+)
+async def list_documents() -> Iterable[DocumentMetadataPublic]:
     """Return metadata for all processed documents in the local store."""
-    return pipeline.iter_documents()
+    return [document.to_public() for document in pipeline.iter_documents()]
 
 
-@router.get("/{document_id}", summary="Get metadata for a document", response_model=DocumentMetadata)
-async def get_document(document_id: UUID) -> DocumentMetadata:
+@router.get(
+    "/{document_id}",
+    summary="Get metadata for a document",
+    response_model=DocumentMetadataPublic,
+)
+async def get_document(document_id: UUID) -> DocumentMetadataPublic:
     """Fetch stored metadata for an individual document."""
     try:
-        return pipeline.get_document(document_id)
+        document = pipeline.get_document(document_id)
     except DocumentNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Document not found") from exc
+    return document.to_public()
 
 
 @router.get("/{document_id}/qa", summary="Ask a question about a document")

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -36,6 +36,37 @@ class DocumentMetadata(BaseModel):
     pii_secret_path: Path | None = None
     extra: dict[str, Any] = Field(default_factory=dict)
 
+    def to_public(self) -> "DocumentMetadataPublic":
+        """Expose a sanitized view suitable for API responses."""
+
+        return DocumentMetadataPublic(
+            document_id=self.document_id,
+            title=self.title,
+            created_at=self.created_at,
+            status=self.status,
+            summary=self.summary,
+            obligations=list(self.obligations),
+            penalties=list(self.penalties),
+            deadlines=list(self.deadlines),
+            pii_placeholders=dict(self.pii_placeholders),
+            extra=dict(self.extra),
+        )
+
+
+class DocumentMetadataPublic(BaseModel):
+    """Subset of metadata fields safe to return to API consumers."""
+
+    document_id: UUID
+    title: str
+    created_at: datetime
+    status: DocumentProcessingStatus
+    summary: str | None = None
+    obligations: list[str] = Field(default_factory=list)
+    penalties: list[str] = Field(default_factory=list)
+    deadlines: list[str] = Field(default_factory=list)
+    pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
+    extra: dict[str, Any] = Field(default_factory=dict)
+
 
 class DocumentCreateResponse(BaseModel):
     """Response payload for a document upload."""

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from collections.abc import Iterable
 from pathlib import Path
 from uuid import UUID
@@ -63,11 +64,15 @@ class DocumentPipeline:
 
             secure_dir = self._settings.data_dir / str(document_id) / "secure"
             secure_dir.mkdir(parents=True, exist_ok=True)
+            if os.name != "nt":
+                os.chmod(secure_dir, 0o700)
             secrets_path = secure_dir / "pii_map.json"
             secrets_path.write_text(
                 json.dumps(sanitized.secrets, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
+            if os.name != "nt":
+                os.chmod(secrets_path, 0o600)
 
             metadata.sanitized_path = sanitized_path
             metadata.pii_placeholders = sanitized.entities

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -96,12 +96,21 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert "pii_placeholders" in data
     assert "email" in data["pii_placeholders"]
     assert all("<" in value and ">" in value for value in data["pii_placeholders"]["email"])
+    assert "source_path" not in data
+    assert "sanitized_path" not in data
+    assert "pii_secret_path" not in data
     serialized = json.dumps(data)
     assert "biuro@example.com" not in serialized
 
+    metadata = documents_module.pipeline.get_document(document_id)
+
     from sqlite3 import connect
 
-    with connect(Path(data["pii_secret_path"]).parents[2] / "metadata.db") as conn:
+    from app.core.config import get_settings
+
+    settings = get_settings()
+
+    with connect(Path(settings.data_dir) / "metadata.db") as conn:
         row = conn.execute(
             "SELECT payload FROM documents WHERE document_id = ?",
             (str(document_id),),
@@ -109,7 +118,8 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
         assert row is not None
         assert "biuro@example.com" not in row[0]
 
-    secret_path = Path(data["pii_secret_path"])
+    assert metadata.pii_secret_path is not None
+    secret_path = Path(metadata.pii_secret_path)
     assert secret_path.exists()
     secrets_payload = secret_path.read_text(encoding="utf-8")
     assert "biuro@example.com" in secrets_payload
@@ -120,6 +130,26 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     )
     answer = qa_response.json()["answer"]
     assert "Źródła" in answer
+
+
+def test_document_listing_does_not_expose_paths(client_and_modules):
+    client, _ = client_and_modules
+    payload = "Art. 1. Dane wrażliwe są zamaskowane.".encode("utf-8")
+
+    response = client.post("/documents/", files={"file": ("dokument.txt", payload, "text/plain")})
+
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    listing = client.get("/documents/")
+    assert listing.status_code == 200
+    documents = listing.json()
+    assert any(entry["document_id"] == str(document_id) for entry in documents)
+
+    for entry in documents:
+        assert "source_path" not in entry
+        assert "sanitized_path" not in entry
+        assert "pii_secret_path" not in entry
 
 
 def test_repository_survives_restart(client_and_modules):

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import json
 import sqlite3
 import sys
@@ -107,5 +108,40 @@ def test_pipeline_persists_only_placeholders(tmp_path, monkeypatch):
         placeholders = json.loads(secrets_content)
         assert placeholders["email"]["<EMAIL_1>"] == "biuro@example.com"
         assert placeholders["pesel"]["<PESEL_1>"] == "12345678901"
+    finally:
+        config.get_settings.cache_clear()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support POSIX permission checks")
+def test_secure_artifacts_have_restrictive_permissions(tmp_path, monkeypatch):
+    pytest.importorskip("pydantic")
+    monkeypatch.setenv("PROSTE_PRAWO_DATA_DIR", str(tmp_path))
+    from app.core import config
+    from app.models.documents import DocumentMetadata
+    from app.services.pipeline import DocumentPipeline
+
+    config.get_settings.cache_clear()
+    try:
+        pipeline = DocumentPipeline()
+
+        metadata = DocumentMetadata(title="regulamin.txt")
+        document_dir = tmp_path / str(metadata.document_id) / "raw"
+        document_dir.mkdir(parents=True, exist_ok=True)
+        source_path = document_dir / "regulamin.txt"
+        source_path.write_text("Art. 1. Poufne dane.", encoding="utf-8")
+        metadata.source_path = source_path
+
+        pipeline.repository.upsert(metadata)
+        asyncio.run(pipeline._run_pipeline(metadata.document_id))
+
+        processed = pipeline.get_document(metadata.document_id)
+        assert processed.pii_secret_path is not None
+        secure_dir = processed.pii_secret_path.parent
+
+        dir_mode = secure_dir.stat().st_mode & 0o777
+        file_mode = processed.pii_secret_path.stat().st_mode & 0o777
+
+        assert dir_mode == 0o700
+        assert file_mode == 0o600
     finally:
         config.get_settings.cache_clear()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ Monolityczna aplikacja FastAPI z serwowanym statycznie frontendem React ma upro�
 1. Użytkownik wgrywa plik → `/documents`.
 2. Pipeline zapisuje plik w `data/{docId}/raw`, tworzy rekord metadanych i rozpoczyna asynchroniczne przetwarzanie.
 3. Ingestion normalizuje tekst, identyfikuje strukturę, wykrywa język i sekcje.
-4. Sanitizer zamienia wrażliwe dane na tagi (<PESEL_1>, <IMIE_2>), zapisuje mapowanie w zaszyfrowanym magazynie.
+4. Sanitizer zamienia wrażliwe dane na tagi (<PESEL_1>, <IMIE_2>), zapisuje mapowanie w magazynie `data/{docId}/secure` z uprawnieniami 700/600.
 5. Indeksowanie tworzy wektory + indeks BM25, zapisuje metadane (sygnatura, numer Dz.U., okres obowiązywania) w SQL/Elastic.
 6. Moduł Inference generuje uproszczenia, streszczenia i listy obowiązków/kar, zapisuje cytowane jednostki.
 7. Użytkownik może pobrać eksport (PDF/DOCX/Markdown) lub zadać pytanie Q&A z cytatem.


### PR DESCRIPTION
## Summary
- add a public document metadata schema and use it in the API so responses omit on-disk paths
- harden the pipeline by locking down permissions for the secure PII map directory and file
- extend tests and documentation to cover the restricted payloads and filesystem permissions

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68ddc558a5d0832694fe018dec024c5a