### PR TITLE
Add document export endpoint and improve pipeline utilities

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -3,13 +3,18 @@ from collections.abc import Iterable
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, UploadFile
+from fastapi.responses import PlainTextResponse
 
 from ...models.documents import (
     DocumentCreateResponse,
     DocumentMetadata,
     DocumentMetadataPublic,
 )
-from ...services.pipeline import DocumentNotFoundError, DocumentPipeline
+from ...services.pipeline import (
+    DocumentNotFoundError,
+    DocumentNotReadyError,
+    DocumentPipeline,
+)
 
 router = APIRouter()
 
@@ -55,3 +60,23 @@ async def ask_question(document_id: UUID, question: str) -> dict[str, str]:
     except DocumentNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Document not found") from exc
     return {"answer": answer}
+
+
+@router.get(
+    "/{document_id}/export",
+    summary="Generate a lightweight export for a document",
+    response_class=PlainTextResponse,
+)
+async def export_document(document_id: UUID, format: str = "markdown") -> PlainTextResponse:
+    """Return a Markdown representation of the processed document."""
+
+    try:
+        content = await pipeline.export_document(document_id=document_id, format=format)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
+    except DocumentNotReadyError as exc:
+        raise HTTPException(status_code=409, detail="Document is still processing") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    media_type = "text/markdown" if format.lower() == "markdown" else "text/plain"
+    return PlainTextResponse(content, media_type=media_type)

--- a/backend/app/services/exporter.py
+++ b/backend/app/services/exporter.py
@@ -1,0 +1,82 @@
+"""Utilities for generating export artefacts from processed documents."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from ..models.documents import DocumentMetadata
+
+
+def generate_markdown(metadata: DocumentMetadata) -> str:
+    """Return a Markdown report describing ``metadata`` and its findings."""
+
+    lines: list[str] = []
+    title = metadata.title or "Dokument"
+    lines.append(f"# {title}")
+    lines.append("")
+
+    created_at = _format_datetime(metadata.created_at)
+    lines.append(f"- **ID dokumentu:** `{metadata.document_id}`")
+    lines.append(f"- **Data utworzenia:** {created_at}")
+    lines.append(f"- **Status przetwarzania:** {metadata.status.value}")
+    lines.append("")
+    lines.append(
+        "> Niniejsze opracowanie ma charakter informacyjny i nie stanowi porady prawnej."
+    )
+    lines.append("")
+
+    if metadata.summary:
+        lines.append("## Podsumowanie")
+        lines.append("")
+        lines.append(metadata.summary.strip())
+        lines.append("")
+
+    _extend_with_list(lines, "Twoje obowiązki", metadata.obligations)
+    _extend_with_list(lines, "Potencjalne kary", metadata.penalties)
+    _extend_with_list(lines, "Kluczowe terminy", metadata.deadlines)
+
+    if metadata.pii_placeholders:
+        lines.append("## Maskowane dane")
+        lines.append("")
+        for key in sorted(metadata.pii_placeholders):
+            placeholders = ", ".join(metadata.pii_placeholders[key]) or "brak"
+            lines.append(f"- **{key}:** {placeholders}")
+        lines.append("")
+
+    sanitized_text = _read_sanitized_text(metadata)
+    if sanitized_text:
+        lines.append("## Tekst po anonimizacji")
+        lines.append("")
+        lines.append("```")
+        lines.append(sanitized_text.strip())
+        lines.append("```")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(
+        "Wygenerowano automatycznie przez moduł eksportu ProstePrawo. "
+        "Zweryfikuj treść przed dalszym wykorzystaniem."
+    )
+    return "\n".join(lines).strip() + "\n"
+
+
+def _extend_with_list(lines: list[str], header: str, items: Iterable[str]) -> None:
+    items = [item.strip() for item in items if item.strip()]
+    if not items:
+        return
+    lines.append(f"## {header}")
+    lines.append("")
+    for item in items:
+        lines.append(f"- {item}")
+    lines.append("")
+
+
+def _read_sanitized_text(metadata: DocumentMetadata) -> str:
+    path = metadata.sanitized_path
+    if not path or not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.replace(microsecond=0).isoformat()

--- a/backend/app/services/indexing.py
+++ b/backend/app/services/indexing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import math
+import re
 from collections import Counter
 from typing import Iterable
 from uuid import UUID
@@ -17,6 +18,9 @@ class RetrievedChunk:
     identifier: str
     score: float
     text: str
+
+
+_TOKEN_PATTERN = re.compile(r"\w+", re.UNICODE)
 
 
 class SimpleIndexer:
@@ -66,4 +70,4 @@ class SimpleIndexer:
 
 
 def _tokenize(text: str) -> list[str]:
-    return [token.lower() for token in text.split() if token]
+    return [token.lower() for token in _TOKEN_PATTERN.findall(text)]

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -13,7 +13,7 @@ from fastapi import UploadFile
 from ..core.config import get_settings
 from ..models.documents import DocumentMetadata, DocumentProcessingStatus
 from ..repositories import DocumentRepository
-from . import inference, ingestion, indexing, sanitizer
+from . import exporter, inference, ingestion, indexing, sanitizer
 
 
 class DocumentNotFoundError(KeyError):
@@ -21,6 +21,15 @@ class DocumentNotFoundError(KeyError):
 
     def __init__(self, document_id: UUID) -> None:
         message = f"Document with id {document_id} was not found"
+        super().__init__(message)
+        self.document_id = document_id
+
+
+class DocumentNotReadyError(RuntimeError):
+    """Raised when an operation requires a fully processed document."""
+
+    def __init__(self, document_id: UUID) -> None:
+        message = f"Document with id {document_id} is not ready"
         super().__init__(message)
         self.document_id = document_id
 
@@ -42,7 +51,12 @@ class DocumentPipeline:
         metadata = DocumentMetadata(title=file.filename or "unknown")
         await self._persist_upload(file, metadata)
         self.repository.upsert(metadata)
-        asyncio.create_task(self._run_pipeline(metadata.document_id))
+        loop = asyncio.get_running_loop()
+
+        def _runner() -> None:
+            asyncio.run(self._run_pipeline(metadata.document_id))
+
+        loop.run_in_executor(None, _runner)
         return metadata
 
     async def _run_pipeline(self, document_id: UUID) -> None:
@@ -100,11 +114,27 @@ class DocumentPipeline:
         if metadata.status != DocumentProcessingStatus.READY:
             return "Dokument jest nadal przetwarzany. Spróbuj ponownie później."
         retrieved = await asyncio.to_thread(self._indexer.retrieve, document_id, question, 3)
+        if not retrieved and metadata.obligations:
+            obligations = "; ".join(metadata.obligations[:3])
+            return (
+                "Na podstawie zapisanych obowiązków dokument wskazuje: "
+                f"{obligations}"
+            )
         answer = inference.answer_question(question, retrieved)
         if answer.sources:
             sources = ", ".join(answer.sources)
             return f"{answer.content} Źródła: {sources}."
         return answer.content
+
+    async def export_document(self, document_id: UUID, format: str = "markdown") -> str:
+        """Generate an export artefact for ``document_id`` in the given ``format``."""
+
+        metadata = self._get(document_id)
+        if metadata.status != DocumentProcessingStatus.READY:
+            raise DocumentNotReadyError(document_id)
+        if format.lower() != "markdown":
+            raise ValueError(f"Unsupported export format: {format}")
+        return await asyncio.to_thread(exporter.generate_markdown, metadata)
 
     def iter_documents(self) -> Iterable[DocumentMetadata]:
         return list(self.repository.list())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Pytest configuration and runtime compatibility patches."""
+from __future__ import annotations
+
+"""Pytest configuration and compatibility shims for the test suite."""
+
+import inspect
+import typing
+
+
+def _ensure_forward_ref_compatibility() -> None:
+    forward_ref = getattr(typing, "ForwardRef", None)
+    if forward_ref is None:
+        return
+    original = getattr(forward_ref, "_evaluate", None)
+    if original is None:
+        return
+    signature = inspect.signature(original)
+    keyword_only = [param for param in signature.parameters.values() if param.kind is inspect.Parameter.KEYWORD_ONLY]
+    if not keyword_only:
+        return
+
+    def _patched(self, globalns, localns, *positional, **kwargs):  # type: ignore[override]
+        positional = list(positional)
+        if "recursive_guard" not in kwargs:
+            if positional:
+                kwargs["recursive_guard"] = positional.pop()
+            else:
+                kwargs["recursive_guard"] = set()
+        return original(self, globalns, localns, *positional, **kwargs)
+
+    setattr(forward_ref, "_evaluate", _patched)
+
+
+_ensure_forward_ref_compatibility()

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -215,3 +215,37 @@ def test_indexing_is_isolated_between_documents(client_and_modules):
     assert "Alfa" in alpha_answer
     assert "Beta" in beta_answer
     assert "Alfa" not in beta_answer
+
+
+def test_markdown_export_returns_sanitized_content(client_and_modules):
+    client, _ = client_and_modules
+    payload = (
+        "Art. 1. Należy dostarczyć dokumenty w terminie 7 dni.\n"
+        "Kontakt: biuro@example.com."
+    ).encode()
+    response = client.post("/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    export_response = client.get(f"/documents/{document_id}/export", params={"format": "markdown"})
+
+    assert export_response.status_code == 200
+    assert export_response.headers["content-type"].startswith("text/markdown")
+    body = export_response.text
+    assert "# regulamin.txt" in body
+    assert "<EMAIL_1>" in body
+    assert "biuro@example.com" not in body
+    assert "## Podsumowanie" in body
+
+
+def test_export_rejects_unsupported_format(client_and_modules):
+    client, _ = client_and_modules
+    payload = "Art. 1. Dane wrażliwe.".encode("utf-8")
+    response = client.post("/documents/", files={"file": ("dokument.txt", payload, "text/plain")})
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    export_response = client.get(f"/documents/{document_id}/export", params={"format": "pdf"})
+
+    assert export_response.status_code == 400
+    assert "Unsupported export format" in export_response.json()["detail"]


### PR DESCRIPTION
## Summary
- add a /documents/{id}/export endpoint that streams markdown exports with proper error handling
- introduce an exporter service, tokenizer improvements, and safer pipeline execution including an obligations-based QA fallback
- extend the test suite with export coverage and a forward-ref compatibility shim for Python 3.12

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68deb32a93e88326ad1ee1870c988a36