### PR TITLE
Add plain-language document sections and API endpoint

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -7,8 +7,8 @@ from fastapi.responses import PlainTextResponse
 
 from ...models.documents import (
     DocumentCreateResponse,
-    DocumentMetadata,
     DocumentMetadataPublic,
+    DocumentSimplifiedResponse,
 )
 from ...services.pipeline import (
     DocumentNotFoundError,
@@ -80,3 +80,20 @@ async def export_document(document_id: UUID, format: str = "markdown") -> PlainT
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     media_type = "text/markdown" if format.lower() == "markdown" else "text/plain"
     return PlainTextResponse(content, media_type=media_type)
+
+
+@router.get(
+    "/{document_id}/simplified",
+    summary="Retrieve plain-language sections for a document",
+    response_model=DocumentSimplifiedResponse,
+)
+async def get_simplified_document(document_id: UUID) -> DocumentSimplifiedResponse:
+    """Return sanitized excerpts paired with simplified explanations."""
+
+    try:
+        sections = pipeline.get_simplified_sections(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
+    except DocumentNotReadyError as exc:
+        raise HTTPException(status_code=409, detail="Document is still processing") from exc
+    return DocumentSimplifiedResponse(document_id=document_id, sections=sections)

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -10,6 +10,21 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, Field
 
 
+class SectionSimplification(BaseModel):
+    """Plain-language representation of a document fragment."""
+
+    identifier: str
+    source_excerpt: str
+    plain_language: str
+
+
+class DocumentSimplifiedResponse(BaseModel):
+    """Payload returned for simplified document views."""
+
+    document_id: UUID
+    sections: list[SectionSimplification] = Field(default_factory=list)
+
+
 class DocumentProcessingStatus(str, Enum):
     """Enumerate the high-level processing states for documents."""
 
@@ -34,6 +49,7 @@ class DocumentMetadata(BaseModel):
     deadlines: list[str] = Field(default_factory=list)
     pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
     pii_secret_path: Path | None = None
+    simplified_sections: list[SectionSimplification] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
 
     def to_public(self) -> "DocumentMetadataPublic":
@@ -49,6 +65,7 @@ class DocumentMetadata(BaseModel):
             penalties=list(self.penalties),
             deadlines=list(self.deadlines),
             pii_placeholders=dict(self.pii_placeholders),
+            simplified_sections=list(self.simplified_sections),
             extra=dict(self.extra),
         )
 
@@ -65,6 +82,7 @@ class DocumentMetadataPublic(BaseModel):
     penalties: list[str] = Field(default_factory=list)
     deadlines: list[str] = Field(default_factory=list)
     pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
+    simplified_sections: list[SectionSimplification] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/backend/app/services/exporter.py
+++ b/backend/app/services/exporter.py
@@ -35,6 +35,18 @@ def generate_markdown(metadata: DocumentMetadata) -> str:
     _extend_with_list(lines, "Potencjalne kary", metadata.penalties)
     _extend_with_list(lines, "Kluczowe terminy", metadata.deadlines)
 
+    if metadata.simplified_sections:
+        lines.append("## Uproszczone brzmienie")
+        lines.append("")
+        for section in metadata.simplified_sections:
+            lines.append(f"### {section.identifier}")
+            lines.append("")
+            if section.source_excerpt:
+                lines.append(f"> {section.source_excerpt}")
+                lines.append("")
+            lines.append(section.plain_language.strip())
+            lines.append("")
+
     if metadata.pii_placeholders:
         lines.append("## Maskowane dane")
         lines.append("")

--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 import textwrap
 from typing import Iterable
 
+from ..models.documents import SectionSimplification
 from .indexing import RetrievedChunk
+from .ingestion import DocumentSection
 
 
 @dataclass(slots=True)
@@ -63,3 +66,88 @@ def answer_question(question: str, retrieved_chunks: list[RetrievedChunk]) -> Qa
     )
     sources = [chunk.identifier for chunk in retrieved_chunks]
     return QaAnswer(content=content, sources=sources)
+
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_AMOUNT_PATTERN = re.compile(r"(\d[\d\s\u00a0]*)(?:\s*)(zł|pln)", re.IGNORECASE)
+_DEADLINE_PATTERN = re.compile(r"(\d+[\s\u00a0]*)(dni|dzień|dnia|miesi(?:ą|a)c)", re.IGNORECASE)
+_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bNiniejszym\b", re.IGNORECASE), "Tym dokumentem"),
+    (re.compile(r"\bNiniejsza\b", re.IGNORECASE), "Ta"),
+    (re.compile(r"\bNiniejszy\b", re.IGNORECASE), "Ten"),
+    (re.compile(r"\bStrony\b", re.IGNORECASE), "osoby"),
+    (re.compile(r"\bStrona\b", re.IGNORECASE), "osoba"),
+    (re.compile(r"\bjest zobowiązan[ay]\b(?:\s+do)?", re.IGNORECASE), "musi"),
+    (re.compile(r"\bzobowiązan[ey]\b", re.IGNORECASE), "ma obowiązek"),
+    (re.compile(r"\bNależy\b", re.IGNORECASE), "Trzeba"),
+    (re.compile(r"\bPowinien\b", re.IGNORECASE), "Powinieneś"),
+    (re.compile(r"\bW terminie\b", re.IGNORECASE), "W ciągu"),
+    (re.compile(r"\bKara umowna\b", re.IGNORECASE), "Kara"),
+    (re.compile(r"\bArt\.\s*(\d+)\b", re.IGNORECASE), r"Artykuł \1"),
+    (re.compile(r"§"), "paragraf"),
+)
+
+
+def simplify_sections(sections: Iterable[DocumentSection]) -> list[SectionSimplification]:
+    """Generate naive plain-language explanations for document sections."""
+
+    simplifications: list[SectionSimplification] = []
+    for section in sections:
+        plain_text = _simplify_text(section.text)
+        excerpt = _create_excerpt(section.text)
+        simplifications.append(
+            SectionSimplification(
+                identifier=section.identifier,
+                source_excerpt=excerpt,
+                plain_language=plain_text,
+            )
+        )
+    return simplifications
+
+
+def _simplify_text(text: str) -> str:
+    sentences = [segment.strip() for segment in _SENTENCE_SPLIT.split(text) if segment and segment.strip()]
+    if not sentences:
+        sentences = [text.strip()]
+    simplified: list[str] = []
+    for sentence in sentences:
+        simplified_sentence = sentence
+        for pattern, replacement in _REPLACEMENTS:
+            simplified_sentence = pattern.sub(replacement, simplified_sentence)
+        simplified_sentence = re.sub(r"\s+", " ", simplified_sentence).strip()
+        if not simplified_sentence:
+            continue
+        simplified_sentence = simplified_sentence[0].upper() + simplified_sentence[1:]
+        if simplified_sentence[-1] not in ".!?":
+            simplified_sentence += "."
+        simplified.append(simplified_sentence)
+    insights = _derive_insights(text)
+    if insights:
+        simplified.append("Ważne informacje: " + " ".join(insights))
+    content = " ".join(simplified)
+    if not content:
+        content = "Tekst nie zawiera szczegółów do uproszczenia."
+    return f"W prostych słowach: {content}"
+
+
+def _derive_insights(text: str) -> list[str]:
+    insights: list[str] = []
+    seen: set[str] = set()
+    for match in _DEADLINE_PATTERN.finditer(text):
+        value = f"Masz {match.group(1).strip()} {match.group(2).lower()} na wykonanie zadania."
+        if value not in seen:
+            seen.add(value)
+            insights.append(value)
+    for match in _AMOUNT_PATTERN.finditer(text):
+        amount = f"Kwota to {match.group(1).strip()} {match.group(2).upper()}."
+        if amount not in seen:
+            seen.add(amount)
+            insights.append(amount)
+    return insights
+
+
+def _create_excerpt(text: str) -> str:
+    collapsed = re.sub(r"\s+", " ", text).strip()
+    if len(collapsed) <= 280:
+        return collapsed
+    return collapsed[:277] + "..."

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -11,7 +11,11 @@ from uuid import UUID
 from fastapi import UploadFile
 
 from ..core.config import get_settings
-from ..models.documents import DocumentMetadata, DocumentProcessingStatus
+from ..models.documents import (
+    DocumentMetadata,
+    DocumentProcessingStatus,
+    SectionSimplification,
+)
 from ..repositories import DocumentRepository
 from . import exporter, inference, ingestion, indexing, sanitizer
 
@@ -101,6 +105,7 @@ class DocumentPipeline:
             metadata.obligations = inference.extract_obligations(sanitized.text)
             metadata.penalties = inference.extract_penalties(sanitized.text)
             metadata.deadlines = inference.extract_deadlines(sanitized.text)
+            metadata.simplified_sections = inference.simplify_sections(sanitized_sections)
             metadata.status = DocumentProcessingStatus.READY
             self.repository.upsert(metadata)
         except Exception as exc:  # pragma: no cover - defensive path
@@ -141,6 +146,12 @@ class DocumentPipeline:
 
     def get_document(self, document_id: UUID) -> DocumentMetadata:
         return self._get(document_id)
+
+    def get_simplified_sections(self, document_id: UUID) -> list[SectionSimplification]:
+        metadata = self._get(document_id)
+        if metadata.status != DocumentProcessingStatus.READY:
+            raise DocumentNotReadyError(document_id)
+        return list(metadata.simplified_sections)
 
     async def _persist_upload(self, file: UploadFile, metadata: DocumentMetadata) -> None:
         filename = Path(file.filename).name if file.filename else "document"

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -102,6 +102,13 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     serialized = json.dumps(data)
     assert "biuro@example.com" not in serialized
 
+    simplified_sections = data["simplified_sections"]
+    assert simplified_sections
+    first_section = simplified_sections[0]
+    assert first_section["plain_language"].startswith("W prostych słowach")
+    assert "należy" not in first_section["plain_language"].lower()
+    assert "<EMAIL_1>" in " ".join(section["plain_language"] for section in simplified_sections)
+
     metadata = documents_module.pipeline.get_document(document_id)
 
     from sqlite3 import connect
@@ -236,6 +243,30 @@ def test_markdown_export_returns_sanitized_content(client_and_modules):
     assert "<EMAIL_1>" in body
     assert "biuro@example.com" not in body
     assert "## Podsumowanie" in body
+    assert "## Uproszczone brzmienie" in body
+    assert "W prostych słowach" in body
+
+
+def test_simplified_endpoint_exposes_plain_language_sections(client_and_modules):
+    client, _ = client_and_modules
+    payload = (
+        "Art. 1. Należy dostarczyć dokumenty w terminie 7 dni.\n"
+        "Art. 2. Kara umowna wynosi 5000 zł."
+    ).encode()
+
+    response = client.post("/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    simplified_response = client.get(f"/documents/{document_id}/simplified")
+    assert simplified_response.status_code == 200
+    simplified = simplified_response.json()
+    assert simplified["document_id"] == str(document_id)
+    assert simplified["sections"]
+    plain_texts = [section["plain_language"] for section in simplified["sections"]]
+    assert any(text.startswith("W prostych słowach") for text in plain_texts)
+    assert all("należy" not in text.lower() for text in plain_texts)
+    assert any("5000" in text for text in plain_texts)
 
 
 def test_export_rejects_unsupported_format(client_and_modules):


### PR DESCRIPTION
## Summary
- add SectionSimplification models and persist plain-language sections during pipeline processing
- expose `/documents/{id}/simplified` endpoint and enrich markdown exports with simplified content
- extend heuristic inference to rewrite sections and cover new test cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68deb8b6791c83269569b1cec9302491