### PR TITLE
Add glossary extraction and endpoint for document definitions

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -7,7 +7,9 @@ from fastapi.responses import PlainTextResponse
 
 from ...models.documents import (
     DocumentCreateResponse,
+    DocumentDefinitionsResponse,
     DocumentMetadataPublic,
+    DocumentProcessingStatus,
     DocumentSimplifiedResponse,
 )
 from ...services.pipeline import (
@@ -97,3 +99,20 @@ async def get_simplified_document(document_id: UUID) -> DocumentSimplifiedRespon
     except DocumentNotReadyError as exc:
         raise HTTPException(status_code=409, detail="Document is still processing") from exc
     return DocumentSimplifiedResponse(document_id=document_id, sections=sections)
+
+
+@router.get(
+    "/{document_id}/definitions",
+    summary="Retrieve glossary definitions for a document",
+    response_model=DocumentDefinitionsResponse,
+)
+async def get_definitions(document_id: UUID) -> DocumentDefinitionsResponse:
+    """Expose extracted legal definitions for the document."""
+
+    try:
+        metadata = pipeline.get_document(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
+    if metadata.status != DocumentProcessingStatus.READY:
+        raise HTTPException(status_code=409, detail="Document is still processing")
+    return DocumentDefinitionsResponse(document_id=document_id, definitions=metadata.definitions)

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -18,6 +18,14 @@ class SectionSimplification(BaseModel):
     plain_language: str
 
 
+class DocumentDefinition(BaseModel):
+    """Definition of a legal term detected in the source material."""
+
+    term: str
+    meaning: str
+    source: str | None = None
+
+
 class DocumentSimplifiedResponse(BaseModel):
     """Payload returned for simplified document views."""
 
@@ -50,6 +58,7 @@ class DocumentMetadata(BaseModel):
     pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
     pii_secret_path: Path | None = None
     simplified_sections: list[SectionSimplification] = Field(default_factory=list)
+    definitions: list[DocumentDefinition] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
 
     def to_public(self) -> "DocumentMetadataPublic":
@@ -66,6 +75,7 @@ class DocumentMetadata(BaseModel):
             deadlines=list(self.deadlines),
             pii_placeholders=dict(self.pii_placeholders),
             simplified_sections=list(self.simplified_sections),
+            definitions=list(self.definitions),
             extra=dict(self.extra),
         )
 
@@ -83,6 +93,7 @@ class DocumentMetadataPublic(BaseModel):
     deadlines: list[str] = Field(default_factory=list)
     pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
     simplified_sections: list[SectionSimplification] = Field(default_factory=list)
+    definitions: list[DocumentDefinition] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -91,3 +102,10 @@ class DocumentCreateResponse(BaseModel):
 
     document_id: UUID
     status: DocumentProcessingStatus
+
+
+class DocumentDefinitionsResponse(BaseModel):
+    """Response payload for the definitions endpoint."""
+
+    document_id: UUID
+    definitions: list[DocumentDefinition] = Field(default_factory=list)

--- a/backend/app/services/exporter.py
+++ b/backend/app/services/exporter.py
@@ -35,6 +35,18 @@ def generate_markdown(metadata: DocumentMetadata) -> str:
     _extend_with_list(lines, "Potencjalne kary", metadata.penalties)
     _extend_with_list(lines, "Kluczowe terminy", metadata.deadlines)
 
+    if metadata.definitions:
+        lines.append("## Kluczowe definicje")
+        lines.append("")
+        for definition in metadata.definitions:
+            lines.append(f"### {definition.term}")
+            lines.append("")
+            lines.append(definition.meaning.strip())
+            lines.append("")
+            if definition.source:
+                lines.append(f"> Źródło: {definition.source.strip()}")
+                lines.append("")
+
     if metadata.simplified_sections:
         lines.append("## Uproszczone brzmienie")
         lines.append("")

--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -6,7 +6,7 @@ import re
 import textwrap
 from typing import Iterable
 
-from ..models.documents import SectionSimplification
+from ..models.documents import DocumentDefinition, SectionSimplification
 from .indexing import RetrievedChunk
 from .ingestion import DocumentSection
 
@@ -71,6 +71,12 @@ def answer_question(question: str, retrieved_chunks: list[RetrievedChunk]) -> Qa
 _SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
 _AMOUNT_PATTERN = re.compile(r"(\d[\d\s\u00a0]*)(?:\s*)(zł|pln)", re.IGNORECASE)
 _DEADLINE_PATTERN = re.compile(r"(\d+[\s\u00a0]*)(dni|dzień|dnia|miesi(?:ą|a)c)", re.IGNORECASE)
+_DEFINITION_VERB_PATTERN = re.compile(
+    r"[„\"']?(?P<term>[A-ZŁŚŻŹĆÓ][^\"”'\n]{1,80}?)[”\"']?\s+"
+    r"(?:oznacza|zwan[ayoe]?|zwanych|zwanym|rozumie się jako|należy rozumieć jako)\s+"
+    r"(?P<definition>[^.;]+)",
+    re.IGNORECASE,
+)
 _REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\bNiniejszym\b", re.IGNORECASE), "Tym dokumentem"),
     (re.compile(r"\bNiniejsza\b", re.IGNORECASE), "Ta"),
@@ -151,3 +157,87 @@ def _create_excerpt(text: str) -> str:
     if len(collapsed) <= 280:
         return collapsed
     return collapsed[:277] + "..."
+
+
+def extract_definitions(text: str) -> list[DocumentDefinition]:
+    """Derive a glossary of legal terms from sanitised text."""
+
+    definitions: dict[str, DocumentDefinition] = {}
+    for sentence in _iter_definition_candidates(text):
+        for term, meaning in _parse_definition_sentence(sentence):
+            if not term or not meaning:
+                continue
+            key = term.lower()
+            if key in definitions:
+                continue
+            definitions[key] = DocumentDefinition(
+                term=term,
+                meaning=meaning,
+                source=sentence.strip(),
+            )
+    return list(definitions.values())
+
+
+def _iter_definition_candidates(text: str) -> Iterable[str]:
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        # Process both raw lines and sentence-level splits to capture multi-line definitions.
+        yield stripped
+        for sentence in _SENTENCE_SPLIT.split(stripped):
+            sentence = sentence.strip()
+            if sentence and sentence != stripped:
+                yield sentence
+
+
+def _parse_definition_sentence(sentence: str) -> Iterable[tuple[str, str]]:
+    matches = []
+    verb_match = _DEFINITION_VERB_PATTERN.search(sentence)
+    if verb_match:
+        matches.append(
+            (
+                _normalise_term(verb_match.group("term")),
+                _clean_meaning(verb_match.group("definition")),
+            )
+        )
+    separator_match = _split_definition_by_separator(sentence)
+    if separator_match:
+        matches.append(separator_match)
+    for term, meaning in matches:
+        term = term.strip()
+        meaning = meaning.strip()
+        if len(term) > 1 and len(meaning) > 3:
+            yield term, meaning
+
+
+def _split_definition_by_separator(sentence: str) -> tuple[str, str] | None:
+    # Support patterns such as "Klient – osoba fizyczna ..." or "Klient: osoba ..."
+    separator: str | None = None
+    for token in (" – ", " - ", " — ", ":", " –", "-", "—"):
+        if token in sentence:
+            separator = token
+            break
+    if not separator:
+        return None
+    parts = sentence.split(separator, 1)
+    if len(parts) != 2:
+        return None
+    term, definition = parts[0].strip(), parts[1].strip()
+    if len(term.split()) > 6:
+        return None
+    if not term or not definition:
+        return None
+    return _normalise_term(term), _clean_meaning(definition)
+
+
+def _normalise_term(term: str) -> str:
+    cleaned = term.strip().strip("'\"”„“»«")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned
+
+
+def _clean_meaning(meaning: str) -> str:
+    cleaned = meaning.strip().rstrip(".;")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -106,6 +106,7 @@ class DocumentPipeline:
             metadata.penalties = inference.extract_penalties(sanitized.text)
             metadata.deadlines = inference.extract_deadlines(sanitized.text)
             metadata.simplified_sections = inference.simplify_sections(sanitized_sections)
+            metadata.definitions = inference.extract_definitions(sanitized.text)
             metadata.status = DocumentProcessingStatus.READY
             self.repository.upsert(metadata)
         except Exception as exc:  # pragma: no cover - defensive path

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -81,6 +81,8 @@ def _wait_for_status(client: TestClient, document_id: UUID, expected: str, timeo
 def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     client, documents_module = client_and_modules
     payload = (
+        "Na potrzeby regulaminu \"Usługodawca\" oznacza ProstePrawo Sp. z o.o.\n"
+        "Klient – osoba fizyczna korzystająca z usług.\n"
         "Art. 1. Należy dostarczyć dokumenty w terminie 7 dni.\n"
         "Art. 2. Kara umowna wynosi 5000 zł.\n"
         "Kontakt: biuro@example.com."
@@ -108,6 +110,10 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert first_section["plain_language"].startswith("W prostych słowach")
     assert "należy" not in first_section["plain_language"].lower()
     assert "<EMAIL_1>" in " ".join(section["plain_language"] for section in simplified_sections)
+
+    definitions = data["definitions"]
+    assert any(entry["term"] == "Usługodawca" for entry in definitions)
+    assert any("osoba fizyczna" in entry["meaning"] for entry in definitions)
 
     metadata = documents_module.pipeline.get_document(document_id)
 
@@ -227,6 +233,7 @@ def test_indexing_is_isolated_between_documents(client_and_modules):
 def test_markdown_export_returns_sanitized_content(client_and_modules):
     client, _ = client_and_modules
     payload = (
+        "Na potrzeby regulaminu \"Usługodawca\" oznacza ProstePrawo Sp. z o.o.\n"
         "Art. 1. Należy dostarczyć dokumenty w terminie 7 dni.\n"
         "Kontakt: biuro@example.com."
     ).encode()
@@ -243,6 +250,8 @@ def test_markdown_export_returns_sanitized_content(client_and_modules):
     assert "<EMAIL_1>" in body
     assert "biuro@example.com" not in body
     assert "## Podsumowanie" in body
+    assert "## Kluczowe definicje" in body
+    assert "### Usługodawca" in body
     assert "## Uproszczone brzmienie" in body
     assert "W prostych słowach" in body
 
@@ -267,6 +276,27 @@ def test_simplified_endpoint_exposes_plain_language_sections(client_and_modules)
     assert any(text.startswith("W prostych słowach") for text in plain_texts)
     assert all("należy" not in text.lower() for text in plain_texts)
     assert any("5000" in text for text in plain_texts)
+
+
+def test_definitions_endpoint_returns_glossary(client_and_modules):
+    client, _ = client_and_modules
+    payload = (
+        "\"Regulamin\" oznacza zbiór zasad.\n"
+        "Usługodawca - podmiot świadczący usługi."
+    ).encode("utf-8")
+
+    response = client.post("/documents/", files={"file": ("slownik.txt", payload, "text/plain")})
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    definitions_response = client.get(f"/documents/{document_id}/definitions")
+    assert definitions_response.status_code == 200
+    data = definitions_response.json()
+    assert data["document_id"] == str(document_id)
+    terms = {entry["term"]: entry["meaning"] for entry in data["definitions"]}
+    assert "Regulamin" in terms
+    assert "zbiór zasad" in terms["Regulamin"].lower()
+    assert "Usługodawca" in terms
 
 
 def test_export_rejects_unsupported_format(client_and_modules):


### PR DESCRIPTION
## Summary
- add document definition models and public response payloads
- integrate definition extraction into the pipeline and expose a dedicated endpoint
- surface glossary entries in Markdown exports and extend API tests for the new behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dee2136c808326b1e551d6ff84c48e