### PR TITLE
Add checklist insights endpoint and risk extraction

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -11,6 +11,7 @@ from ...models.documents import (
     DocumentMetadataPublic,
     DocumentProcessingStatus,
     DocumentSimplifiedResponse,
+    DocumentInsightsResponse,
 )
 from ...services.pipeline import (
     DocumentNotFoundError,
@@ -116,3 +117,20 @@ async def get_definitions(document_id: UUID) -> DocumentDefinitionsResponse:
     if metadata.status != DocumentProcessingStatus.READY:
         raise HTTPException(status_code=409, detail="Document is still processing")
     return DocumentDefinitionsResponse(document_id=document_id, definitions=metadata.definitions)
+
+
+@router.get(
+    "/{document_id}/insights",
+    summary="Retrieve checklist-style insights for a document",
+    response_model=DocumentInsightsResponse,
+)
+async def get_insights(document_id: UUID) -> DocumentInsightsResponse:
+    """Expose summary, obligations, penalties, deadlines and risks for a document."""
+
+    try:
+        insights = pipeline.get_document_insights(document_id)
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Document not found") from exc
+    except DocumentNotReadyError as exc:
+        raise HTTPException(status_code=409, detail="Document is still processing") from exc
+    return DocumentInsightsResponse(document_id=document_id, **insights)

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -55,6 +55,7 @@ class DocumentMetadata(BaseModel):
     obligations: list[str] = Field(default_factory=list)
     penalties: list[str] = Field(default_factory=list)
     deadlines: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
     pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
     pii_secret_path: Path | None = None
     simplified_sections: list[SectionSimplification] = Field(default_factory=list)
@@ -73,6 +74,7 @@ class DocumentMetadata(BaseModel):
             obligations=list(self.obligations),
             penalties=list(self.penalties),
             deadlines=list(self.deadlines),
+            risks=list(self.risks),
             pii_placeholders=dict(self.pii_placeholders),
             simplified_sections=list(self.simplified_sections),
             definitions=list(self.definitions),
@@ -91,6 +93,7 @@ class DocumentMetadataPublic(BaseModel):
     obligations: list[str] = Field(default_factory=list)
     penalties: list[str] = Field(default_factory=list)
     deadlines: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
     pii_placeholders: dict[str, list[str]] = Field(default_factory=dict)
     simplified_sections: list[SectionSimplification] = Field(default_factory=list)
     definitions: list[DocumentDefinition] = Field(default_factory=list)
@@ -109,3 +112,14 @@ class DocumentDefinitionsResponse(BaseModel):
 
     document_id: UUID
     definitions: list[DocumentDefinition] = Field(default_factory=list)
+
+
+class DocumentInsightsResponse(BaseModel):
+    """Response payload for checklist-style document insights."""
+
+    document_id: UUID
+    summary: str | None = None
+    obligations: list[str] = Field(default_factory=list)
+    penalties: list[str] = Field(default_factory=list)
+    deadlines: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)

--- a/backend/app/services/exporter.py
+++ b/backend/app/services/exporter.py
@@ -34,6 +34,7 @@ def generate_markdown(metadata: DocumentMetadata) -> str:
     _extend_with_list(lines, "Twoje obowiązki", metadata.obligations)
     _extend_with_list(lines, "Potencjalne kary", metadata.penalties)
     _extend_with_list(lines, "Kluczowe terminy", metadata.deadlines)
+    _extend_with_list(lines, "Potencjalne ryzyka", metadata.risks)
 
     if metadata.definitions:
         lines.append("## Kluczowe definicje")

--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -55,6 +55,10 @@ def extract_deadlines(text: str) -> list[str]:
     return _collect_sentences(text, ["termin", "dni", "miesiąc", "miesiac"])
 
 
+def extract_risks(text: str) -> list[str]:
+    return _collect_sentences(text, ["ryzyk", "zagroż", "niebezpiecz", "utrata", "szkody"])
+
+
 def answer_question(question: str, retrieved_chunks: list[RetrievedChunk]) -> QaAnswer:
     if not retrieved_chunks:
         return QaAnswer(content="Brak danych pozwalających na udzielenie odpowiedzi.", sources=[])

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -105,6 +105,7 @@ class DocumentPipeline:
             metadata.obligations = inference.extract_obligations(sanitized.text)
             metadata.penalties = inference.extract_penalties(sanitized.text)
             metadata.deadlines = inference.extract_deadlines(sanitized.text)
+            metadata.risks = inference.extract_risks(sanitized.text)
             metadata.simplified_sections = inference.simplify_sections(sanitized_sections)
             metadata.definitions = inference.extract_definitions(sanitized.text)
             metadata.status = DocumentProcessingStatus.READY
@@ -153,6 +154,18 @@ class DocumentPipeline:
         if metadata.status != DocumentProcessingStatus.READY:
             raise DocumentNotReadyError(document_id)
         return list(metadata.simplified_sections)
+
+    def get_document_insights(self, document_id: UUID) -> dict[str, object]:
+        metadata = self._get(document_id)
+        if metadata.status != DocumentProcessingStatus.READY:
+            raise DocumentNotReadyError(document_id)
+        return {
+            "summary": metadata.summary,
+            "obligations": list(metadata.obligations),
+            "penalties": list(metadata.penalties),
+            "deadlines": list(metadata.deadlines),
+            "risks": list(metadata.risks),
+        }
 
     async def _persist_upload(self, file: UploadFile, metadata: DocumentMetadata) -> None:
         filename = Path(file.filename).name if file.filename else "document"

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -85,6 +85,7 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
         "Klient – osoba fizyczna korzystająca z usług.\n"
         "Art. 1. Należy dostarczyć dokumenty w terminie 7 dni.\n"
         "Art. 2. Kara umowna wynosi 5000 zł.\n"
+        "Ryzyko utraty dostępu występuje w przypadku braku płatności.\n"
         "Kontakt: biuro@example.com."
     ).encode()
     response = client.post("/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
@@ -98,6 +99,8 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert "pii_placeholders" in data
     assert "email" in data["pii_placeholders"]
     assert all("<" in value and ">" in value for value in data["pii_placeholders"]["email"])
+    assert data["risks"]
+    assert any("ryzyko" in entry.lower() for entry in data["risks"])
     assert "source_path" not in data
     assert "sanitized_path" not in data
     assert "pii_secret_path" not in data
@@ -163,6 +166,7 @@ def test_document_listing_does_not_expose_paths(client_and_modules):
         assert "source_path" not in entry
         assert "sanitized_path" not in entry
         assert "pii_secret_path" not in entry
+        assert "risks" in entry
 
 
 def test_repository_survives_restart(client_and_modules):
@@ -235,6 +239,7 @@ def test_markdown_export_returns_sanitized_content(client_and_modules):
     payload = (
         "Na potrzeby regulaminu \"Usługodawca\" oznacza ProstePrawo Sp. z o.o.\n"
         "Art. 1. Należy dostarczyć dokumenty w terminie 7 dni.\n"
+        "Istnieje ryzyko naliczenia odsetek przy braku płatności.\n"
         "Kontakt: biuro@example.com."
     ).encode()
     response = client.post("/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
@@ -254,6 +259,7 @@ def test_markdown_export_returns_sanitized_content(client_and_modules):
     assert "### Usługodawca" in body
     assert "## Uproszczone brzmienie" in body
     assert "W prostych słowach" in body
+    assert "## Potencjalne ryzyka" in body
 
 
 def test_simplified_endpoint_exposes_plain_language_sections(client_and_modules):
@@ -297,6 +303,29 @@ def test_definitions_endpoint_returns_glossary(client_and_modules):
     assert "Regulamin" in terms
     assert "zbiór zasad" in terms["Regulamin"].lower()
     assert "Usługodawca" in terms
+
+
+def test_insights_endpoint_returns_checklists(client_and_modules):
+    client, _ = client_and_modules
+    payload = (
+        "Art. 1. Należy złożyć wniosek w terminie 14 dni.\n"
+        "Art. 2. Kara za opóźnienie to 200 zł.\n"
+        "W przeciwnym razie istnieje ryzyko utraty świadczenia."
+    ).encode("utf-8")
+
+    response = client.post("/documents/", files={"file": ("checklist.txt", payload, "text/plain")})
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    insights_response = client.get(f"/documents/{document_id}/insights")
+    assert insights_response.status_code == 200
+    data = insights_response.json()
+    assert data["document_id"] == str(document_id)
+    assert any("wniosek" in entry.lower() for entry in data["obligations"])
+    assert any("200" in entry for entry in data["penalties"])
+    assert any("14" in entry for entry in data["deadlines"])
+    assert any("ryzyko" in entry.lower() for entry in data["risks"])
+    assert data["summary"]
 
 
 def test_export_rejects_unsupported_format(client_and_modules):


### PR DESCRIPTION
## Summary
- extend document metadata to track risk sentences alongside obligations, penalties, and deadlines
- expose the checklist data via a new `/documents/{id}/insights` endpoint and include risks in the markdown export
- expand the rule-based inference logic and tests to cover risk detection and the new endpoint

## Testing
- pytest *(FastAPI-dependent suites skipped automatically because FastAPI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dee516d2f48326af6f2ed8f667e193