### PR TITLE
Add Docker setup for backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ roadmap.md (plan rozwoju)
 
 4. Otwórz dokumentację interaktywną: [http://localhost:8000/docs](http://localhost:8000/docs).
 
+## Uruchomienie w Dockerze
+
+1. Zbuduj obraz oraz uruchom kontenery za pomocą Docker Compose:
+   ```bash
+   docker compose build
+   docker compose up
+   ```
+
+2. W razie potrzeby ustaw zmienne środowiskowe (np. `OPENAI_API_KEY`) w pliku `.env` w katalogu głównym lub przekazuj je przy wywołaniu `docker compose`.
+
+3. Domyślnie wolumen `./data` montowany jest do `/app/data` wewnątrz kontenera. Umożliwia to zachowanie wgrywanych dokumentów pomiędzy restartami. Dostosuj ścieżki lub usuń wolumen w `docker-compose.yml`, jeśli nie jest potrzebny.
+
 ## Dalszy rozwój
 
 - Postępy i plan prac znajdziesz w pliku [`roadmap.md`](./roadmap.md).

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+tests/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    volumes:
+      - ./data:/app/data


### PR DESCRIPTION
## Summary
- add a backend Dockerfile based on python:3.12-slim and configure uvicorn entrypoint
- ignore virtualenv and test assets during Docker build
- introduce docker-compose service for running the backend and document Docker usage in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dee787784883268a990054104d7084