### PR TITLE
Add example environment configuration file

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,11 @@
+# Sample environment configuration for the ProstePrawo project.
+# Duplicate this file as `.env` and adjust the values to fit your setup.
+
+# Core application settings
+PROSTE_PRAWO_DATA_DIR=data
+PROSTE_PRAWO_ENABLE_CLOUD_LLM=true
+PROSTE_PRAWO_LLM_PROVIDER=openai
+PROSTE_PRAWO_OPENAI_MODEL=gpt-4o-mini
+
+# External services
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ roadmap.md (plan rozwoju)
    ```
 
 2. Skonfiguruj zmienne środowiskowe (np. `OPENAI_API_KEY`, ścieżki do Elasticsearch/FAISS) i katalog na pliki (`/data`).
+   Możesz skopiować plik `.example.env` do `.env` i uzupełnić wartości zgodnie ze swoją konfiguracją.
 
 3. Uruchom serwer deweloperski:
    ```bash
@@ -75,7 +76,8 @@ roadmap.md (plan rozwoju)
    docker compose up
    ```
 
-2. W razie potrzeby ustaw zmienne środowiskowe (np. `OPENAI_API_KEY`) w pliku `.env` w katalogu głównym lub przekazuj je przy wywołaniu `docker compose`.
+2. W razie potrzeby ustaw zmienne środowiskowe (np. `OPENAI_API_KEY`) w pliku `.env` w katalogu głównym
+   (najłatwiej skopiować `.example.env`) lub przekazuj je przy wywołaniu `docker compose`.
 
 3. Domyślnie wolumen `./data` montowany jest do `/app/data` wewnątrz kontenera. Umożliwia to zachowanie wgrywanych dokumentów pomiędzy restartami. Dostosuj ścieżki lub usuń wolumen w `docker-compose.yml`, jeśli nie jest potrzebny.
 


### PR DESCRIPTION
## Summary
- add a `.example.env` template listing all environment variables used by the project
- document how to use the example environment file when configuring local and Docker setups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee9a274348326a505d8a2c83ffcd9