### PR TITLE
Relax Pydantic pin for FastAPI 0.111

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,3 @@
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
-pydantic==1.10.15
+pydantic>=2.7,<3.0


### PR DESCRIPTION
## Summary
- update the backend requirements to allow FastAPI 0.111.0 to install alongside a compatible Pydantic 2 release

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68df1b068dfc8326b52547217ffc88a6