### PR TITLE
Use pydantic-settings for backend configuration

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
 pydantic>=2.7,<3.0
+pydantic-settings>=2.0,<3.0


### PR DESCRIPTION
## Summary
- update backend settings module to import BaseSettings from pydantic-settings
- add pydantic-settings dependency to backend requirements for Docker builds

## Testing
- docker compose up --build backend *(fails: docker CLI not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e00dfffa6c8326bcb2206ddfd305cd