### PR TITLE
Add frontend PoC and enhance document exports

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, UploadFile
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, Response
 
 from ...models.documents import (
     DocumentCreateResponse,
@@ -68,21 +68,28 @@ async def ask_question(document_id: UUID, question: str) -> dict[str, str]:
 @router.get(
     "/{document_id}/export",
     summary="Generate a lightweight export for a document",
-    response_class=PlainTextResponse,
 )
-async def export_document(document_id: UUID, format: str = "markdown") -> PlainTextResponse:
+async def export_document(
+    document_id: UUID, format: str = "markdown", restore_pii: bool = False
+) -> Response:
     """Return a Markdown representation of the processed document."""
 
     try:
-        content = await pipeline.export_document(document_id=document_id, format=format)
+        artefact = await pipeline.export_document(
+            document_id=document_id, format=format, restore_pii=restore_pii
+        )
     except DocumentNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Document not found") from exc
     except DocumentNotReadyError as exc:
         raise HTTPException(status_code=409, detail="Document is still processing") from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    media_type = "text/markdown" if format.lower() == "markdown" else "text/plain"
-    return PlainTextResponse(content, media_type=media_type)
+    headers = {
+        "Content-Disposition": f'attachment; filename="{artefact.filename}"'
+    }
+    if artefact.media_type.startswith("text/"):
+        return PlainTextResponse(artefact.content.decode("utf-8"), media_type=artefact.media_type, headers=headers)
+    return Response(content=artefact.content, media_type=artefact.media_type, headers=headers)
 
 
 @router.get(

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -15,6 +15,7 @@ class SectionSimplification(BaseModel):
 
     identifier: str
     source_excerpt: str
+    source_text: str = ""
     plain_language: str
 
 

--- a/backend/app/services/exporter.py
+++ b/backend/app/services/exporter.py
@@ -2,14 +2,19 @@
 from __future__ import annotations
 
 from datetime import datetime
+import io
+import json
+import textwrap
 from typing import Iterable
+from zipfile import ZipFile, ZIP_DEFLATED
 
 from ..models.documents import DocumentMetadata
 
 
-def generate_markdown(metadata: DocumentMetadata) -> str:
+def generate_markdown(metadata: DocumentMetadata, *, restore_pii: bool = False) -> str:
     """Return a Markdown report describing ``metadata`` and its findings."""
 
+    replacements = _load_replacements(metadata) if restore_pii else {}
     lines: list[str] = []
     title = metadata.title or "Dokument"
     lines.append(f"# {title}")
@@ -26,26 +31,35 @@ def generate_markdown(metadata: DocumentMetadata) -> str:
     lines.append("")
 
     if metadata.summary:
+        summary = metadata.summary.strip()
+        if restore_pii:
+            summary = _rehydrate(summary, replacements)
         lines.append("## Podsumowanie")
         lines.append("")
-        lines.append(metadata.summary.strip())
+        lines.append(summary)
         lines.append("")
 
-    _extend_with_list(lines, "Twoje obowiązki", metadata.obligations)
-    _extend_with_list(lines, "Potencjalne kary", metadata.penalties)
-    _extend_with_list(lines, "Kluczowe terminy", metadata.deadlines)
-    _extend_with_list(lines, "Potencjalne ryzyka", metadata.risks)
+    _extend_with_list(lines, "Twoje obowiązki", metadata.obligations, replacements if restore_pii else None)
+    _extend_with_list(lines, "Potencjalne kary", metadata.penalties, replacements if restore_pii else None)
+    _extend_with_list(lines, "Kluczowe terminy", metadata.deadlines, replacements if restore_pii else None)
+    _extend_with_list(lines, "Potencjalne ryzyka", metadata.risks, replacements if restore_pii else None)
 
     if metadata.definitions:
         lines.append("## Kluczowe definicje")
         lines.append("")
         for definition in metadata.definitions:
+            meaning = definition.meaning.strip()
+            source = definition.source.strip() if definition.source else None
+            if restore_pii:
+                meaning = _rehydrate(meaning, replacements)
+                if source:
+                    source = _rehydrate(source, replacements)
             lines.append(f"### {definition.term}")
             lines.append("")
-            lines.append(definition.meaning.strip())
+            lines.append(meaning)
             lines.append("")
-            if definition.source:
-                lines.append(f"> Źródło: {definition.source.strip()}")
+            if source:
+                lines.append(f"> Źródło: {source}")
                 lines.append("")
 
     if metadata.simplified_sections:
@@ -54,10 +68,15 @@ def generate_markdown(metadata: DocumentMetadata) -> str:
         for section in metadata.simplified_sections:
             lines.append(f"### {section.identifier}")
             lines.append("")
-            if section.source_excerpt:
-                lines.append(f"> {section.source_excerpt}")
+            excerpt = section.source_excerpt
+            plain = section.plain_language.strip()
+            if restore_pii:
+                excerpt = _rehydrate(excerpt, replacements)
+                plain = _rehydrate(plain, replacements)
+            if excerpt:
+                lines.append(f"> {excerpt}")
                 lines.append("")
-            lines.append(section.plain_language.strip())
+            lines.append(plain)
             lines.append("")
 
     if metadata.pii_placeholders:
@@ -70,6 +89,8 @@ def generate_markdown(metadata: DocumentMetadata) -> str:
 
     sanitized_text = _read_sanitized_text(metadata)
     if sanitized_text:
+        if restore_pii:
+            sanitized_text = _rehydrate(sanitized_text, replacements)
         lines.append("## Tekst po anonimizacji")
         lines.append("")
         lines.append("```")
@@ -85,13 +106,98 @@ def generate_markdown(metadata: DocumentMetadata) -> str:
     return "\n".join(lines).strip() + "\n"
 
 
-def _extend_with_list(lines: list[str], header: str, items: Iterable[str]) -> None:
-    items = [item.strip() for item in items if item.strip()]
-    if not items:
+def generate_pdf(metadata: DocumentMetadata, *, restore_pii: bool = False) -> bytes:
+    """Render a lightweight PDF file summarising ``metadata``."""
+
+    text = _generate_plaintext(metadata, restore_pii=restore_pii)
+    stream = _build_pdf_stream(text)
+    return _assemble_pdf(stream)
+
+
+def generate_docx(metadata: DocumentMetadata, *, restore_pii: bool = False) -> bytes:
+    """Produce a DOCX document from ``metadata`` contents."""
+
+    text = _generate_plaintext(metadata, restore_pii=restore_pii)
+    document_xml = _build_docx_document_xml(text)
+    buffer = io.BytesIO()
+    with ZipFile(buffer, "w", ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", _DOCX_CONTENT_TYPES)
+        archive.writestr("_rels/.rels", _DOCX_RELS)
+        archive.writestr("docProps/core.xml", _DOCX_CORE)
+        archive.writestr("docProps/app.xml", _DOCX_APP)
+        archive.writestr("word/document.xml", document_xml)
+    return buffer.getvalue()
+
+
+def _generate_plaintext(metadata: DocumentMetadata, *, restore_pii: bool) -> str:
+    replacements = _load_replacements(metadata) if restore_pii else {}
+    lines: list[str] = []
+    title = metadata.title or "Dokument"
+    lines.append(title)
+    lines.append("=" * len(title))
+    lines.append("")
+    lines.append(f"ID: {metadata.document_id}")
+    lines.append(f"Utworzono: {_format_datetime(metadata.created_at)}")
+    lines.append(f"Status: {metadata.status.value}")
+    lines.append("")
+    summary = metadata.summary.strip() if metadata.summary else ""
+    if summary:
+        if restore_pii:
+            summary = _rehydrate(summary, replacements)
+        lines.append("Podsumowanie:")
+        lines.append(summary)
+        lines.append("")
+    _extend_plaintext(lines, "Obowiązki", metadata.obligations, replacements if restore_pii else None)
+    _extend_plaintext(lines, "Kary", metadata.penalties, replacements if restore_pii else None)
+    _extend_plaintext(lines, "Terminy", metadata.deadlines, replacements if restore_pii else None)
+    _extend_plaintext(lines, "Ryzyka", metadata.risks, replacements if restore_pii else None)
+    if metadata.simplified_sections:
+        lines.append("Sekcje:")
+        for section in metadata.simplified_sections:
+            excerpt = section.source_excerpt
+            plain = section.plain_language
+            if restore_pii:
+                excerpt = _rehydrate(excerpt, replacements)
+                plain = _rehydrate(plain, replacements)
+            lines.append(f"- {section.identifier}")
+            if excerpt:
+                lines.append(f"  Oryginał: {excerpt}")
+            lines.append(f"  Uproszczenie: {plain}")
+        lines.append("")
+    sanitized_text = _read_sanitized_text(metadata)
+    if sanitized_text:
+        if restore_pii:
+            sanitized_text = _rehydrate(sanitized_text, replacements)
+        lines.append("Pełny tekst:")
+        lines.extend(textwrap.wrap(sanitized_text, width=90))
+    return "\n".join(lines).strip()
+
+
+def _extend_with_list(
+    lines: list[str], header: str, items: Iterable[str], replacements: dict[str, str] | None
+) -> None:
+    values = [item.strip() for item in items if item and item.strip()]
+    if not values:
         return
     lines.append(f"## {header}")
     lines.append("")
-    for item in items:
+    for item in values:
+        if replacements:
+            item = _rehydrate(item, replacements)
+        lines.append(f"- {item}")
+    lines.append("")
+
+
+def _extend_plaintext(
+    lines: list[str], header: str, items: Iterable[str], replacements: dict[str, str] | None
+) -> None:
+    values = [item.strip() for item in items if item and item.strip()]
+    if not values:
+        return
+    lines.append(f"{header}:")
+    for item in values:
+        if replacements:
+            item = _rehydrate(item, replacements)
         lines.append(f"- {item}")
     lines.append("")
 
@@ -105,3 +211,123 @@ def _read_sanitized_text(metadata: DocumentMetadata) -> str:
 
 def _format_datetime(value: datetime) -> str:
     return value.replace(microsecond=0).isoformat()
+
+
+def _load_replacements(metadata: DocumentMetadata) -> dict[str, str]:
+    path = metadata.pii_secret_path
+    if not path or not path.exists():
+        return {}
+    try:
+        content = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    replacements: dict[str, str] = {}
+    for mapping in content.values():
+        for placeholder, value in mapping.items():
+            replacements[placeholder] = value
+    return replacements
+
+
+def _rehydrate(text: str, replacements: dict[str, str]) -> str:
+    restored = text
+    for placeholder, value in replacements.items():
+        restored = restored.replace(placeholder, value)
+    return restored
+
+
+def _build_pdf_stream(text: str) -> bytes:
+    safe_lines = [line.replace("\\", "\\\\").replace("(", r"\(").replace(")", r"\)") for line in text.splitlines()]
+    commands = ["BT", "/F1 12 Tf", "14 TL", "72 800 Td"]
+    for index, line in enumerate(safe_lines):
+        if index == 0:
+            commands.append(f"({line}) Tj")
+        else:
+            commands.append("T*")
+            commands.append(f"({line}) Tj")
+    commands.append("ET")
+    return "\n".join(commands).encode("latin-1", errors="ignore")
+
+
+def _assemble_pdf(stream: bytes) -> bytes:
+    buffer = io.BytesIO()
+    buffer.write(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets: list[int] = [0]
+
+    def _write_obj(obj_id: int, payload: bytes) -> None:
+        offsets.append(buffer.tell())
+        buffer.write(f"{obj_id} 0 obj\n".encode("ascii"))
+        buffer.write(payload)
+        buffer.write(b"\nendobj\n")
+
+    _write_obj(1, b"<< /Type /Catalog /Pages 2 0 R >>")
+    _write_obj(2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+    _write_obj(
+        3,
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+    )
+    content = b"<< /Length " + str(len(stream)).encode("ascii") + b" >>\nstream\n" + stream + b"\nendstream"
+    _write_obj(4, content)
+    _write_obj(5, b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    xref_position = buffer.tell()
+    buffer.write(b"xref\n0 6\n0000000000 65535 f \n")
+    for position in offsets[1:]:
+        buffer.write(f"{position:010d} 00000 n \n".encode("ascii"))
+    buffer.write(b"trailer << /Size 6 /Root 1 0 R >>\nstartxref\n")
+    buffer.write(str(xref_position).encode("ascii"))
+    buffer.write(b"\n%%EOF")
+    return buffer.getvalue()
+
+
+def _build_docx_document_xml(text: str) -> str:
+    paragraphs = []
+    for line in text.splitlines() or [""]:
+        escaped = (
+            line.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&apos;")
+        )
+        paragraphs.append(
+            "<w:p><w:r><w:t xml:space=\"preserve\">{}</w:t></w:r></w:p>".format(escaped if escaped else "")
+        )
+    body = "".join(paragraphs)
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">"
+        f"<w:body>{body}</w:body></w:document>"
+    )
+
+
+_DOCX_CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+  <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
+</Types>
+"""
+
+_DOCX_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
+</Relationships>
+"""
+
+_DOCX_CORE = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dc:title>Eksport dokumentu ProstePrawo</dc:title>
+  <dc:creator>ProstePrawo</dc:creator>
+  <cp:lastModifiedBy>ProstePrawo</cp:lastModifiedBy>
+</cp:coreProperties>
+"""
+
+_DOCX_APP = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+  <Application>ProstePrawo</Application>
+</Properties>
+"""

--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -109,6 +109,7 @@ def simplify_sections(sections: Iterable[DocumentSection]) -> list[SectionSimpli
             SectionSimplification(
                 identifier=section.identifier,
                 source_excerpt=excerpt,
+                source_text=section.text,
                 plain_language=plain_text,
             )
         )

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import json
 import os
 from collections.abc import Iterable
@@ -18,6 +19,15 @@ from ..models.documents import (
 )
 from ..repositories import DocumentRepository
 from . import exporter, inference, ingestion, indexing, sanitizer
+
+
+@dataclass(slots=True)
+class ExportArtefact:
+    """Binary representation of an exported document."""
+
+    filename: str
+    media_type: str
+    content: bytes
 
 
 class DocumentNotFoundError(KeyError):
@@ -133,15 +143,47 @@ class DocumentPipeline:
             return f"{answer.content} Źródła: {sources}."
         return answer.content
 
-    async def export_document(self, document_id: UUID, format: str = "markdown") -> str:
+    async def export_document(
+        self,
+        document_id: UUID,
+        format: str = "markdown",
+        restore_pii: bool = False,
+    ) -> ExportArtefact:
         """Generate an export artefact for ``document_id`` in the given ``format``."""
 
         metadata = self._get(document_id)
         if metadata.status != DocumentProcessingStatus.READY:
             raise DocumentNotReadyError(document_id)
-        if format.lower() != "markdown":
+
+        normalised = format.lower()
+        supported = {"markdown", "pdf", "docx"}
+        if normalised not in supported:
             raise ValueError(f"Unsupported export format: {format}")
-        return await asyncio.to_thread(exporter.generate_markdown, metadata)
+
+        if restore_pii and (not metadata.pii_secret_path or not metadata.pii_secret_path.exists()):
+            raise ValueError("Original PII mapping is unavailable for this document")
+
+        if normalised == "markdown":
+            payload = await asyncio.to_thread(exporter.generate_markdown, metadata, restore_pii=restore_pii)
+            return ExportArtefact(
+                filename=f"{document_id}.md",
+                media_type="text/markdown",
+                content=payload.encode("utf-8"),
+            )
+        if normalised == "pdf":
+            payload = await asyncio.to_thread(exporter.generate_pdf, metadata, restore_pii=restore_pii)
+            return ExportArtefact(
+                filename=f"{document_id}.pdf",
+                media_type="application/pdf",
+                content=payload,
+            )
+
+        payload = await asyncio.to_thread(exporter.generate_docx, metadata, restore_pii=restore_pii)
+        return ExportArtefact(
+            filename=f"{document_id}.docx",
+            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            content=payload,
+        )
 
     def iter_documents(self) -> Iterable[DocumentMetadata]:
         return list(self.repository.list())

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import io
 import json
 import time
 from pathlib import Path
@@ -12,6 +13,7 @@ import pytest
 
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
+from zipfile import ZipFile
 
 
 @pytest.fixture
@@ -113,6 +115,7 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert first_section["plain_language"].startswith("W prostych słowach")
     assert "należy" not in first_section["plain_language"].lower()
     assert "<EMAIL_1>" in " ".join(section["plain_language"] for section in simplified_sections)
+    assert first_section["source_text"].startswith("Na potrzeby regulaminu")
 
     definitions = data["definitions"]
     assert any(entry["term"] == "Usługodawca" for entry in definitions)
@@ -146,6 +149,11 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     )
     answer = qa_response.json()["answer"]
     assert "Źródła" in answer
+
+    simplified_payload = client.get(f"/documents/{document_id}/simplified")
+    simplified_payload.raise_for_status()
+    simplified_data = simplified_payload.json()
+    assert simplified_data["sections"][0]["source_text"].startswith("Na potrzeby regulaminu")
 
 
 def test_document_listing_does_not_expose_paths(client_and_modules):
@@ -189,6 +197,65 @@ def test_repository_survives_restart(client_and_modules):
 
     answer = asyncio.run(new_pipeline.answer_question(document_id, "Jakie są obowiązki stron?"))
     assert "obowiąz" in answer.lower()
+
+
+def test_export_endpoints_support_formats_and_restore(client_and_modules):
+    client, documents_module = client_and_modules
+    payload = (
+        "Umowa zawiera dane kontaktowe: biuro@example.com.\n"
+        "Art. 1. Należy przesłać dokumenty w terminie 5 dni."
+    ).encode("utf-8")
+    response = client.post("/documents/", files={"file": ("umowa.txt", payload, "text/plain")})
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    markdown = client.get(f"/documents/{document_id}/export", params={"format": "markdown"})
+    assert markdown.status_code == 200
+    assert markdown.headers["content-type"].startswith("text/markdown")
+    assert "<EMAIL_" in markdown.text
+
+    restored = client.get(
+        f"/documents/{document_id}/export",
+        params={"format": "markdown", "restore_pii": "true"},
+    )
+    assert restored.status_code == 200
+    assert "biuro@example.com" in restored.text
+
+    pdf_export = client.get(f"/documents/{document_id}/export", params={"format": "pdf"})
+    assert pdf_export.status_code == 200
+    assert pdf_export.headers["content-type"] == "application/pdf"
+    assert pdf_export.content.startswith(b"%PDF")
+
+    docx_export = client.get(f"/documents/{document_id}/export", params={"format": "docx"})
+    assert docx_export.status_code == 200
+    assert docx_export.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument"
+    )
+    with ZipFile(io.BytesIO(docx_export.content)) as archive:
+        with archive.open("word/document.xml") as xml_document:
+            xml_payload = xml_document.read().decode("utf-8")
+    assert "Umowa" in xml_payload
+
+    metadata = documents_module.pipeline.get_document(document_id)
+    assert metadata.pii_secret_path and metadata.pii_secret_path.exists()
+
+
+def test_export_restore_requires_secret_map(client_and_modules):
+    client, documents_module = client_and_modules
+    payload = "Kontakt: osoba@example.com".encode("utf-8")
+    response = client.post("/documents/", files={"file": ("kontakt.txt", payload, "text/plain")})
+    document_id = UUID(response.json()["document_id"])
+    _wait_for_status(client, document_id, "ready")
+
+    metadata = documents_module.pipeline.get_document(document_id)
+    assert metadata.pii_secret_path is not None
+    metadata.pii_secret_path.unlink()
+
+    restore_attempt = client.get(
+        f"/documents/{document_id}/export", params={"format": "markdown", "restore_pii": "true"}
+    )
+    assert restore_attempt.status_code == 400
+    assert "unavailable" in restore_attempt.json()["detail"].lower()
 
 
 def test_indexing_is_isolated_between_documents(client_and_modules):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ProstePrawo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "proste-prawo-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.6",
+    "@types/react-dom": "^18.3.3",
+    "@vitejs/plugin-react": "^4.3.2",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,32 @@
+import { Link, NavLink, Route, Routes, useLocation } from 'react-router-dom';
+import DashboardPage from './pages/DashboardPage';
+import ReaderPage from './pages/ReaderPage';
+import ExportPage from './pages/ExportPage';
+
+function App() {
+  const location = useLocation();
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <Link to="/" className="app-logo">
+          ProstePrawo
+        </Link>
+        <nav>
+          <NavLink to="/" className={({ isActive }) => (isActive && location.pathname === '/' ? 'active' : '')}>
+            Dashboard
+          </NavLink>
+        </nav>
+      </header>
+      <main className="app-main">
+        <Routes>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/documents/:documentId" element={<ReaderPage />} />
+          <Route path="/documents/:documentId/export" element={<ExportPage />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router-dom';
+import type { DocumentListItem } from '../types';
+
+interface DocumentListProps {
+  documents: DocumentListItem[];
+  isLoading: boolean;
+  onRefresh: () => void;
+}
+
+function DocumentList({ documents, isLoading, onRefresh }: DocumentListProps) {
+  return (
+    <section className="panel">
+      <header className="panel-header">
+        <h2>Twoje dokumenty</h2>
+        <button type="button" onClick={onRefresh} disabled={isLoading}>
+          Odśwież
+        </button>
+      </header>
+      {isLoading && <p>Wczytywanie listy dokumentów...</p>}
+      {!isLoading && documents.length === 0 && <p>Brak dokumentów. Prześlij plik aby rozpocząć analizę.</p>}
+      <ul className="document-list">
+        {documents.map((document) => (
+          <li key={document.document_id} className={`document-item status-${document.status}`}>
+            <div>
+              <p className="document-title">{document.title}</p>
+              <p className="document-meta">
+                Utworzono: {new Date(document.created_at).toLocaleString('pl-PL')} • Status: {document.status}
+              </p>
+            </div>
+            <div className="document-actions">
+              <Link to={`/documents/${document.document_id}`}>Otwórz</Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default DocumentList;

--- a/frontend/src/components/QaModal.tsx
+++ b/frontend/src/components/QaModal.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useState } from 'react';
+import { API_BASE_URL } from '../config';
+import type { QaResponse } from '../types';
+
+interface QaModalProps {
+  documentId: string;
+  onClose: () => void;
+  onHighlightSource: (identifier: string) => void;
+}
+
+function extractSources(answer: string): string[] {
+  const marker = 'Źródła:';
+  const index = answer.indexOf(marker);
+  if (index === -1) {
+    return [];
+  }
+  return answer
+    .slice(index + marker.length)
+    .split(/[.,]/)
+    .map((part) => part.trim())
+    .filter((item) => item.length > 0);
+}
+
+function QaModal({ documentId, onClose, onHighlightSource }: QaModalProps) {
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState<QaResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setQuestion('Jakie mam obowiązki?');
+  }, []);
+
+  const sources = useMemo(() => extractSources(answer?.answer ?? ''), [answer]);
+
+  const askQuestion = async () => {
+    if (!question.trim()) {
+      setError('Zadaj pytanie, aby otrzymać odpowiedź.');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    setAnswer(null);
+    try {
+      const params = new URLSearchParams({ question });
+      const response = await fetch(`${API_BASE_URL}/documents/${documentId}/qa?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error('Nie udało się pobrać odpowiedzi.');
+      }
+      const data: QaResponse = await response.json();
+      setAnswer(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Nieznany błąd.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal">
+        <header className="modal-header">
+          <h2>Zapytaj dokument</h2>
+          <button type="button" onClick={onClose} className="close-button" aria-label="Zamknij">
+            ×
+          </button>
+        </header>
+        <div className="modal-content">
+          <label htmlFor="qa-question">Pytanie</label>
+          <textarea
+            id="qa-question"
+            value={question}
+            onChange={(event) => setQuestion(event.target.value)}
+            rows={3}
+            placeholder="Opisz czego chcesz się dowiedzieć..."
+          />
+          <button type="button" onClick={askQuestion} disabled={isLoading}>
+            {isLoading ? 'Szukanie...' : 'Szukaj odpowiedzi'}
+          </button>
+          {error && <p className="error-message">{error}</p>}
+          {answer && (
+            <div className="qa-answer">
+              <p>{answer.answer}</p>
+              {sources.length > 0 && (
+                <div className="qa-sources">
+                  <strong>Źródła:</strong>
+                  <ul>
+                    {sources.map((source) => (
+                      <li key={source}>
+                        <button type="button" onClick={() => onHighlightSource(source)}>
+                          {source}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default QaModal;

--- a/frontend/src/components/SectionViewer.tsx
+++ b/frontend/src/components/SectionViewer.tsx
@@ -1,0 +1,85 @@
+import type { SectionSimplification } from '../types';
+
+interface SectionViewerProps {
+  sections: SectionSimplification[];
+  activeIdentifier: string | null;
+  sideBySide: boolean;
+  onSelect: (identifier: string) => void;
+}
+
+function SectionViewer({ sections, activeIdentifier, sideBySide, onSelect }: SectionViewerProps) {
+  if (sections.length === 0) {
+    return <p>Brak uproszczonych sekcji dla tego dokumentu.</p>;
+  }
+
+  if (sideBySide) {
+    return (
+      <div className="reader split">
+        <div className="reader-column">
+          <h3>Oryginał</h3>
+          <ul className="section-list">
+            {sections.map((section) => (
+              <li
+                key={section.identifier}
+                className={section.identifier === activeIdentifier ? 'active' : ''}
+                data-section-id={section.identifier}
+                onClick={() => onSelect(section.identifier)}
+              >
+                <header>
+                  <strong>{section.identifier}</strong>
+                </header>
+                <p>{section.source_text}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="reader-column">
+          <h3>W prostych słowach</h3>
+          <ul className="section-list">
+            {sections.map((section) => (
+              <li
+                key={`${section.identifier}-plain`}
+                className={section.identifier === activeIdentifier ? 'active' : ''}
+                data-section-id={section.identifier}
+              >
+                <header>
+                  <strong>{section.identifier}</strong>
+                </header>
+                <p>{section.plain_language}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="reader single">
+      <div className="reader-column">
+        <h3>W prostych słowach</h3>
+        <ul className="section-list">
+          {sections.map((section) => (
+            <li
+              key={`${section.identifier}-solo`}
+              className={section.identifier === activeIdentifier ? 'active' : ''}
+              data-section-id={section.identifier}
+              onClick={() => onSelect(section.identifier)}
+            >
+              <header>
+                <strong>{section.identifier}</strong>
+              </header>
+              <p>{section.plain_language}</p>
+              <details>
+                <summary>Fragment oryginału</summary>
+                <p>{section.source_text}</p>
+              </details>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default SectionViewer;

--- a/frontend/src/components/UploadZone.tsx
+++ b/frontend/src/components/UploadZone.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useRef, useState } from 'react';
+import { API_BASE_URL } from '../config';
+
+interface UploadZoneProps {
+  onUploadComplete: () => void;
+}
+
+const ACCEPTED_TYPES = ['.pdf', '.txt', '.md', '.docx'];
+
+function UploadZone({ onUploadComplete }: UploadZoneProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files || files.length === 0) {
+        return;
+      }
+      const file = files[0];
+      const formData = new FormData();
+      formData.append('file', file);
+      setIsUploading(true);
+      setError(null);
+      try {
+        const response = await fetch(`${API_BASE_URL}/documents/`, {
+          method: 'POST',
+          body: formData
+        });
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || 'Nie udało się przesłać pliku.');
+        }
+        onUploadComplete();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Nieznany błąd przesyłania.');
+      } finally {
+        setIsUploading(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+      }
+    },
+    [onUploadComplete]
+  );
+
+  const handleDrop = useCallback(
+    async (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      await uploadFiles(event.dataTransfer.files);
+    },
+    [uploadFiles]
+  );
+
+  const handleSelectFile = useCallback(async () => {
+    await uploadFiles(fileInputRef.current?.files ?? null);
+  }, [uploadFiles]);
+
+  return (
+    <div className="upload-zone">
+      <div
+        className={`drop-area ${isDragging ? 'dragging' : ''}`}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+      >
+        <p>Przeciągnij dokument tutaj lub wybierz z dysku.</p>
+        <button type="button" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>
+          {isUploading ? 'Przesyłanie...' : 'Wybierz plik'}
+        </button>
+        <p className="hint">Obsługiwane formaty: {ACCEPTED_TYPES.join(', ')}</p>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_TYPES.join(',')}
+          hidden
+          onChange={handleSelectFile}
+        />
+      </div>
+      {error && <p className="error-message">{error}</p>}
+    </div>
+  );
+}
+
+export default UploadZone;

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/app.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from 'react';
+import UploadZone from '../components/UploadZone';
+import DocumentList from '../components/DocumentList';
+import { API_BASE_URL } from '../config';
+import type { DocumentListItem } from '../types';
+
+function DashboardPage() {
+  const [documents, setDocuments] = useState<DocumentListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadDocuments = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/documents/`);
+      if (!response.ok) {
+        throw new Error('Nie udało się pobrać dokumentów.');
+      }
+      const data: DocumentListItem[] = await response.json();
+      setDocuments(data);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadDocuments();
+  }, [loadDocuments]);
+
+  return (
+    <div className="dashboard">
+      <section className="panel">
+        <h1>Panel dokumentów</h1>
+        <p>
+          Prześlij dokument aby uruchomić przetwarzanie. Analiza odbywa się lokalnie w środowisku PoC, dlatego odświeżaj
+          listę, aby obserwować status.
+        </p>
+        <UploadZone onUploadComplete={loadDocuments} />
+      </section>
+      <DocumentList documents={documents} isLoading={isLoading} onRefresh={loadDocuments} />
+    </div>
+  );
+}
+
+export default DashboardPage;

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { API_BASE_URL } from '../config';
+
+const EXPORT_FORMATS = [
+  { value: 'markdown', label: 'Markdown (.md)', mime: 'text/markdown' },
+  { value: 'pdf', label: 'PDF (.pdf)', mime: 'application/pdf' },
+  { value: 'docx', label: 'Word (.docx)', mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+];
+
+function ExportPage() {
+  const { documentId } = useParams();
+  const navigate = useNavigate();
+  const [format, setFormat] = useState('markdown');
+  const [restorePii, setRestorePii] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = 'Eksport dokumentu – ProstePrawo';
+    return () => {
+      document.title = 'ProstePrawo';
+    };
+  }, []);
+
+  const handleExport = async () => {
+    if (!documentId) {
+      return;
+    }
+    setIsDownloading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ format, restore_pii: restorePii ? 'true' : 'false' });
+      const response = await fetch(`${API_BASE_URL}/documents/${documentId}/export?${params.toString()}`);
+      if (!response.ok) {
+        const details = await response.text();
+        throw new Error(details || 'Nie udało się wygenerować eksportu.');
+      }
+      const disposition = response.headers.get('content-disposition');
+      const extension = format === 'markdown' ? 'md' : format;
+      const filename = disposition?.match(/filename="?([^";]+)"?/)?.[1] ?? `export-${documentId}.${extension}`;
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Nieznany błąd eksportu.');
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <div className="export-page">
+      <header className="export-header">
+        <button type="button" onClick={() => navigate(-1)}>
+          ← Wróć do dokumentu
+        </button>
+        <h1>Eksport dokumentu</h1>
+      </header>
+      <section className="panel">
+        <h2>Format pliku</h2>
+        <div className="export-options">
+          {EXPORT_FORMATS.map((option) => (
+            <label key={option.value}>
+              <input
+                type="radio"
+                name="export-format"
+                value={option.value}
+                checked={format === option.value}
+                onChange={(event) => setFormat(event.target.value)}
+              />
+              {option.label}
+            </label>
+          ))}
+        </div>
+        <label className="restore-toggle">
+          <input type="checkbox" checked={restorePii} onChange={(event) => setRestorePii(event.target.checked)} />
+          Przywróć PII w eksporcie (tylko lokalnie)
+        </label>
+        <p className="hint">
+          Zaznaczenie tej opcji spowoduje próbę odtworzenia zanonimizowanych danych w wygenerowanym pliku. Wymaga
+          dostępności mapy PII zapisanej podczas przetwarzania dokumentu.
+        </p>
+        <button type="button" onClick={handleExport} disabled={isDownloading}>
+          {isDownloading ? 'Generowanie...' : 'Generuj plik'}
+        </button>
+        {error && <p className="error-message">{error}</p>}
+      </section>
+    </div>
+  );
+}
+
+export default ExportPage;

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { API_BASE_URL } from '../config';
+import SectionViewer from '../components/SectionViewer';
+import QaModal from '../components/QaModal';
+import type { DocumentMetadataPublic, SectionSimplification, SimplifiedResponse } from '../types';
+
+function ReaderPage() {
+  const { documentId } = useParams();
+  const navigate = useNavigate();
+  const [metadata, setMetadata] = useState<DocumentMetadataPublic | null>(null);
+  const [sections, setSections] = useState<SectionSimplification[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sideBySide, setSideBySide] = useState(true);
+  const [activeSection, setActiveSection] = useState<string | null>(null);
+  const [showQa, setShowQa] = useState(false);
+
+  useEffect(() => {
+    if (!documentId) {
+      return;
+    }
+    const fetchData = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const [metaResponse, simplifiedResponse] = await Promise.all([
+          fetch(`${API_BASE_URL}/documents/${documentId}`),
+          fetch(`${API_BASE_URL}/documents/${documentId}/simplified`)
+        ]);
+        if (metaResponse.status === 404) {
+          setError('Nie znaleziono dokumentu.');
+          setIsLoading(false);
+          return;
+        }
+        if (!metaResponse.ok || !simplifiedResponse.ok) {
+          throw new Error('Nie udało się pobrać danych dokumentu.');
+        }
+        const metaJson: DocumentMetadataPublic = await metaResponse.json();
+        const simplifiedJson: SimplifiedResponse = await simplifiedResponse.json();
+        setMetadata(metaJson);
+        setSections(simplifiedJson.sections);
+        setActiveSection(simplifiedJson.sections[0]?.identifier ?? null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Wystąpił nieznany błąd.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchData();
+  }, [documentId]);
+
+  useEffect(() => {
+    if (activeSection) {
+      const element = document.querySelector(`[data-section-id="${CSS.escape(activeSection)}"]`);
+      element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [activeSection]);
+
+  const ready = metadata?.status === 'ready';
+
+  const insights = useMemo(() => {
+    if (!metadata) {
+      return [];
+    }
+    return [
+      { label: 'Obowiązki', data: metadata.obligations },
+      { label: 'Kary', data: metadata.penalties },
+      { label: 'Terminy', data: metadata.deadlines },
+      { label: 'Ryzyka', data: metadata.risks }
+    ];
+  }, [metadata]);
+
+  if (!documentId) {
+    return <p>Brak identyfikatora dokumentu.</p>;
+  }
+
+  return (
+    <div className="reader-page">
+      <header className="reader-header">
+        <div>
+          <button type="button" onClick={() => navigate(-1)}>
+            ← Wróć
+          </button>
+          <h1>{metadata?.title ?? 'Dokument'}</h1>
+          <p>Status: {metadata?.status ?? 'ładowanie...'}</p>
+        </div>
+        <div className="reader-tools">
+          <label>
+            <input type="checkbox" checked={sideBySide} onChange={(event) => setSideBySide(event.target.checked)} />
+            Widok równoległy
+          </label>
+          <button type="button" onClick={() => setShowQa(true)} disabled={!ready}>
+            Q&amp;A
+          </button>
+          <Link to={`/documents/${documentId}/export`} className={`button ${ready ? '' : 'disabled'}`}>
+            Eksport
+          </Link>
+        </div>
+      </header>
+      {isLoading && <p>Ładowanie dokumentu...</p>}
+      {error && <p className="error-message">{error}</p>}
+      {!isLoading && !error && (
+        <>
+          <SectionViewer
+            sections={sections}
+            activeIdentifier={activeSection}
+            sideBySide={sideBySide}
+            onSelect={setActiveSection}
+          />
+          <aside className="reader-insights">
+            <h2>Najważniejsze informacje</h2>
+            {insights.map((group) => (
+              <div key={group.label}>
+                <h3>{group.label}</h3>
+                {group.data.length > 0 ? (
+                  <ul>
+                    {group.data.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>Brak danych.</p>
+                )}
+              </div>
+            ))}
+          </aside>
+        </>
+      )}
+      {showQa && (
+        <QaModal
+          documentId={documentId}
+          onClose={() => setShowQa(false)}
+          onHighlightSource={(identifier) => setActiveSection(identifier)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default ReaderPage;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1,0 +1,333 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1c1f23;
+  background-color: #f7f9fb;
+}
+
+body {
+  margin: 0;
+  background-color: #f7f9fb;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background-color: #1f2933;
+  color: #fff;
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.app-logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.app-header nav a {
+  margin-left: 1rem;
+  color: #d9e2ec;
+  text-decoration: none;
+}
+
+.app-header nav a.active,
+.app-header nav a:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.app-main {
+  flex: 1;
+  padding: 2rem;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.panel {
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+button,
+.button,
+input[type='radio'],
+input[type='checkbox'] {
+  cursor: pointer;
+}
+
+button,
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: #fff;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:disabled,
+.button.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button:not(:disabled):hover,
+.button:not(.disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.upload-zone {
+  border: 2px dashed #cbd5e1;
+  padding: 1.5rem;
+  border-radius: 16px;
+  text-align: center;
+  background: #f8fafc;
+}
+
+.upload-zone .drop-area.dragging {
+  border-color: #38bdf8;
+  background-color: rgba(56, 189, 248, 0.15);
+}
+
+.document-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.document-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+  background-color: #fdfdfd;
+  transition: border-color 0.2s ease;
+}
+
+.document-item.status-ready {
+  border-color: #22c55e;
+}
+
+.document-item.status-processing {
+  border-color: #f97316;
+}
+
+.document-title {
+  margin: 0 0 0.5rem 0;
+  font-weight: 600;
+}
+
+.document-meta {
+  margin: 0;
+  color: #475569;
+}
+
+.error-message {
+  color: #dc2626;
+}
+
+.reader-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.reader-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.reader-header button {
+  margin-right: 0.5rem;
+}
+
+.reader-tools {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reader {
+  display: grid;
+  gap: 1rem;
+}
+
+.reader.split {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.reader.single {
+  grid-template-columns: 1fr;
+}
+
+.reader-column {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-list li {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.75rem;
+  background-color: #f8fafc;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.section-list li.active {
+  border-color: #2563eb;
+  background-color: rgba(37, 99, 235, 0.1);
+}
+
+.reader-insights {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem 1.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.reader-insights ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 16px;
+  max-width: 520px;
+  width: 100%;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal textarea {
+  resize: vertical;
+  min-height: 80px;
+  border-radius: 12px;
+  border: 1px solid #d0d5dd;
+  padding: 0.75rem;
+}
+
+.close-button {
+  background: transparent;
+  color: #1c1f23;
+  font-size: 1.5rem;
+}
+
+.qa-answer {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+.qa-sources ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.qa-sources button {
+  background: #2563eb;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+}
+
+.export-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.export-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.export-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.restore-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.hint {
+  color: #64748b;
+  font-size: 0.9rem;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,32 @@
+export type DocumentStatus = 'received' | 'processing' | 'ready' | 'failed';
+
+export interface SectionSimplification {
+  identifier: string;
+  source_excerpt: string;
+  source_text: string;
+  plain_language: string;
+}
+
+export interface DocumentMetadataPublic {
+  document_id: string;
+  title: string;
+  created_at: string;
+  status: DocumentStatus;
+  summary?: string | null;
+  obligations: string[];
+  penalties: string[];
+  deadlines: string[];
+  risks: string[];
+  simplified_sections: SectionSimplification[];
+}
+
+export interface DocumentListItem extends DocumentMetadataPublic {}
+
+export interface SimplifiedResponse {
+  document_id: string;
+  sections: SectionSimplification[];
+}
+
+export interface QaResponse {
+  answer: string;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    server: {
+      port: Number(env.VITE_PORT ?? 5173),
+      host: true
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: true
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src')
+      }
+    }
+  };
+});


### PR DESCRIPTION
## Summary
- add a Vite/React TypeScript frontend with dashboard, document reader, Q&A modal, and export view wired to the API
- expose full section text in simplified responses and extend export pipeline with PDF/DOCX generation plus optional PII restoration
- update FastAPI routes and tests to cover new export formats and enriched simplified sections

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e01051d6f48326866a96da66f8706e