### PR TITLE
Serve frontend assets from backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,11 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt ./
+COPY backend/requirements.txt ./requirements.txt
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app ./app
+COPY backend/app ./app
+COPY frontend/dist ./frontend/dist
 
 ENV PYTHONUNBUFFERED=1
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,15 +1,64 @@
 """FastAPI entry point for the ProstePrawo monolithic backend."""
-from fastapi import FastAPI
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .api.routes import documents, health
 
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+FRONTEND_DIST_DIR = (BASE_DIR / "frontend" / "dist").resolve()
+INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
+
+
+class SPAStaticFiles(StaticFiles):
+    """Static file handler that falls back to ``index.html`` for SPA routes."""
+
+    async def get_response(self, path: str, scope):  # type: ignore[override]
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404 and INDEX_FILE.exists():
+                return await super().get_response("index.html", scope)
+            raise
+
+
 app = FastAPI(title="ProstePrawo", version="0.1.0")
 
-app.include_router(health.router)
-app.include_router(documents.router, prefix="/documents", tags=["documents"])
+api_router = APIRouter(prefix="/api")
+api_router.include_router(health.router)
+api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
+app.include_router(api_router)
 
 
-@app.get("/", tags=["root"])
-async def read_root() -> dict[str, str]:
-    """Simple root endpoint for smoke-testing deployments."""
-    return {"message": "ProstePrawo API is running"}
+@app.get("/", include_in_schema=False)
+async def serve_frontend_root() -> FileResponse:
+    """Return the compiled frontend entry point."""
+
+    if not INDEX_FILE.exists():
+        raise HTTPException(status_code=503, detail="Frontend build not found")
+    return FileResponse(INDEX_FILE)
+
+
+@app.get("/{full_path:path}", include_in_schema=False)
+async def serve_frontend_spa(full_path: str) -> FileResponse:
+    """Serve static assets or fall back to ``index.html`` for SPA routes."""
+
+    if full_path == "api" or full_path.startswith("api/"):
+        raise HTTPException(status_code=404, detail="Not found")
+    candidate = (FRONTEND_DIST_DIR / full_path).resolve()
+    if candidate.is_file() and FRONTEND_DIST_DIR in candidate.parents:
+        return FileResponse(candidate)
+    if not INDEX_FILE.exists():
+        raise HTTPException(status_code=503, detail="Frontend build not found")
+    return FileResponse(INDEX_FILE)
+
+
+if FRONTEND_DIST_DIR.exists():
+    app.mount("/", SPAStaticFiles(directory=FRONTEND_DIST_DIR, html=True), name="frontend")

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -38,7 +38,7 @@ def test_get_document_missing_returns_404(client_and_modules):
     client, _ = client_and_modules
     missing_id = uuid4()
 
-    response = client.get(f"/documents/{missing_id}")
+    response = client.get(f"/api/documents/{missing_id}")
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Document not found"
@@ -49,7 +49,7 @@ def test_upload_persists_file(client_and_modules):
     payload = b"Postanowienia umowne"
     filename = "umowa.txt"
 
-    response = client.post("/documents/", files={"file": (filename, payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": (filename, payload, "text/plain")})
 
     assert response.status_code == 200
     data = response.json()
@@ -72,7 +72,7 @@ def test_upload_persists_file(client_and_modules):
 def _wait_for_status(client: TestClient, document_id: UUID, expected: str, timeout: float = 5.0) -> dict:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        response = client.get(f"/documents/{document_id}")
+        response = client.get(f"/api/documents/{document_id}")
         data = response.json()
         if data["status"] == expected:
             return data
@@ -90,7 +90,7 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
         "Ryzyko utraty dostępu występuje w przypadku braku płatności.\n"
         "Kontakt: biuro@example.com."
     ).encode()
-    response = client.post("/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
 
     document_id = UUID(response.json()["document_id"])
     data = _wait_for_status(client, document_id, "ready")
@@ -144,13 +144,13 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert "biuro@example.com" in secrets_payload
 
     qa_response = client.get(
-        f"/documents/{document_id}/qa",
+        f"/api/documents/{document_id}/qa",
         params={"question": "Jaka kara grozi za naruszenie?"},
     )
     answer = qa_response.json()["answer"]
     assert "Źródła" in answer
 
-    simplified_payload = client.get(f"/documents/{document_id}/simplified")
+    simplified_payload = client.get(f"/api/documents/{document_id}/simplified")
     simplified_payload.raise_for_status()
     simplified_data = simplified_payload.json()
     assert simplified_data["sections"][0]["source_text"].startswith("Na potrzeby regulaminu")
@@ -160,12 +160,12 @@ def test_document_listing_does_not_expose_paths(client_and_modules):
     client, _ = client_and_modules
     payload = "Art. 1. Dane wrażliwe są zamaskowane.".encode("utf-8")
 
-    response = client.post("/documents/", files={"file": ("dokument.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("dokument.txt", payload, "text/plain")})
 
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
-    listing = client.get("/documents/")
+    listing = client.get("/api/documents/")
     assert listing.status_code == 200
     documents = listing.json()
     assert any(entry["document_id"] == str(document_id) for entry in documents)
@@ -180,7 +180,7 @@ def test_document_listing_does_not_expose_paths(client_and_modules):
 def test_repository_survives_restart(client_and_modules):
     client, documents_module = client_and_modules
     payload = "Art. 1. Strony zobowiązują się do zachowania poufności.".encode("utf-8")
-    response = client.post("/documents/", files={"file": ("umowa.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("umowa.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
@@ -205,28 +205,28 @@ def test_export_endpoints_support_formats_and_restore(client_and_modules):
         "Umowa zawiera dane kontaktowe: biuro@example.com.\n"
         "Art. 1. Należy przesłać dokumenty w terminie 5 dni."
     ).encode("utf-8")
-    response = client.post("/documents/", files={"file": ("umowa.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("umowa.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
-    markdown = client.get(f"/documents/{document_id}/export", params={"format": "markdown"})
+    markdown = client.get(f"/api/documents/{document_id}/export", params={"format": "markdown"})
     assert markdown.status_code == 200
     assert markdown.headers["content-type"].startswith("text/markdown")
     assert "<EMAIL_" in markdown.text
 
     restored = client.get(
-        f"/documents/{document_id}/export",
+        f"/api/documents/{document_id}/export",
         params={"format": "markdown", "restore_pii": "true"},
     )
     assert restored.status_code == 200
     assert "biuro@example.com" in restored.text
 
-    pdf_export = client.get(f"/documents/{document_id}/export", params={"format": "pdf"})
+    pdf_export = client.get(f"/api/documents/{document_id}/export", params={"format": "pdf"})
     assert pdf_export.status_code == 200
     assert pdf_export.headers["content-type"] == "application/pdf"
     assert pdf_export.content.startswith(b"%PDF")
 
-    docx_export = client.get(f"/documents/{document_id}/export", params={"format": "docx"})
+    docx_export = client.get(f"/api/documents/{document_id}/export", params={"format": "docx"})
     assert docx_export.status_code == 200
     assert docx_export.headers["content-type"].startswith(
         "application/vnd.openxmlformats-officedocument"
@@ -243,7 +243,7 @@ def test_export_endpoints_support_formats_and_restore(client_and_modules):
 def test_export_restore_requires_secret_map(client_and_modules):
     client, documents_module = client_and_modules
     payload = "Kontakt: osoba@example.com".encode("utf-8")
-    response = client.post("/documents/", files={"file": ("kontakt.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("kontakt.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
@@ -252,7 +252,7 @@ def test_export_restore_requires_secret_map(client_and_modules):
     metadata.pii_secret_path.unlink()
 
     restore_attempt = client.get(
-        f"/documents/{document_id}/export", params={"format": "markdown", "restore_pii": "true"}
+        f"/api/documents/{document_id}/export", params={"format": "markdown", "restore_pii": "true"}
     )
     assert restore_attempt.status_code == 400
     assert "unavailable" in restore_attempt.json()["detail"].lower()
@@ -271,11 +271,11 @@ def test_indexing_is_isolated_between_documents(client_and_modules):
     ).encode("utf-8")
 
     alpha_response = client.post(
-        "/documents/",
+        "/api/documents/",
         files={"file": ("alpha.txt", alpha_payload, "text/plain")},
     )
     beta_response = client.post(
-        "/documents/",
+        "/api/documents/",
         files={"file": ("beta.txt", beta_payload, "text/plain")},
     )
 
@@ -286,11 +286,11 @@ def test_indexing_is_isolated_between_documents(client_and_modules):
     _wait_for_status(client, beta_id, "ready")
 
     alpha_answer = client.get(
-        f"/documents/{alpha_id}/qa",
+        f"/api/documents/{alpha_id}/qa",
         params={"question": "Czego dotyczy procedura Alfa?"},
     ).json()["answer"]
     beta_answer = client.get(
-        f"/documents/{beta_id}/qa",
+        f"/api/documents/{beta_id}/qa",
         params={"question": "Czego dotyczy zadanie Beta?"},
     ).json()["answer"]
 
@@ -309,11 +309,11 @@ def test_markdown_export_returns_sanitized_content(client_and_modules):
         "Istnieje ryzyko naliczenia odsetek przy braku płatności.\n"
         "Kontakt: biuro@example.com."
     ).encode()
-    response = client.post("/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
-    export_response = client.get(f"/documents/{document_id}/export", params={"format": "markdown"})
+    export_response = client.get(f"/api/documents/{document_id}/export", params={"format": "markdown"})
 
     assert export_response.status_code == 200
     assert export_response.headers["content-type"].startswith("text/markdown")
@@ -336,11 +336,11 @@ def test_simplified_endpoint_exposes_plain_language_sections(client_and_modules)
         "Art. 2. Kara umowna wynosi 5000 zł."
     ).encode()
 
-    response = client.post("/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("regulamin.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
-    simplified_response = client.get(f"/documents/{document_id}/simplified")
+    simplified_response = client.get(f"/api/documents/{document_id}/simplified")
     assert simplified_response.status_code == 200
     simplified = simplified_response.json()
     assert simplified["document_id"] == str(document_id)
@@ -358,11 +358,11 @@ def test_definitions_endpoint_returns_glossary(client_and_modules):
         "Usługodawca - podmiot świadczący usługi."
     ).encode("utf-8")
 
-    response = client.post("/documents/", files={"file": ("slownik.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("slownik.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
-    definitions_response = client.get(f"/documents/{document_id}/definitions")
+    definitions_response = client.get(f"/api/documents/{document_id}/definitions")
     assert definitions_response.status_code == 200
     data = definitions_response.json()
     assert data["document_id"] == str(document_id)
@@ -380,11 +380,11 @@ def test_insights_endpoint_returns_checklists(client_and_modules):
         "W przeciwnym razie istnieje ryzyko utraty świadczenia."
     ).encode("utf-8")
 
-    response = client.post("/documents/", files={"file": ("checklist.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("checklist.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
-    insights_response = client.get(f"/documents/{document_id}/insights")
+    insights_response = client.get(f"/api/documents/{document_id}/insights")
     assert insights_response.status_code == 200
     data = insights_response.json()
     assert data["document_id"] == str(document_id)
@@ -398,11 +398,11 @@ def test_insights_endpoint_returns_checklists(client_and_modules):
 def test_export_rejects_unsupported_format(client_and_modules):
     client, _ = client_and_modules
     payload = "Art. 1. Dane wrażliwe.".encode("utf-8")
-    response = client.post("/documents/", files={"file": ("dokument.txt", payload, "text/plain")})
+    response = client.post("/api/documents/", files={"file": ("dokument.txt", payload, "text/plain")})
     document_id = UUID(response.json()["document_id"])
     _wait_for_status(client, document_id, "ready")
 
-    export_response = client.get(f"/documents/{document_id}/export", params={"format": "pdf"})
+    export_response = client.get(f"/api/documents/{document_id}/export", params={"format": "pdf"})
 
     assert export_response.status_code == 400
     assert "Unsupported export format" in export_response.json()["detail"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ version: "3.9"
 services:
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     ports:
       - "8000:8000"
     environment:

--- a/frontend/dist/assets/app.css
+++ b/frontend/dist/assets/app.css
@@ -1,0 +1,333 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1c1f23;
+  background-color: #f7f9fb;
+}
+
+body {
+  margin: 0;
+  background-color: #f7f9fb;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background-color: #1f2933;
+  color: #fff;
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.app-logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.app-header nav a {
+  margin-left: 1rem;
+  color: #d9e2ec;
+  text-decoration: none;
+}
+
+.app-header nav a.active,
+.app-header nav a:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.app-main {
+  flex: 1;
+  padding: 2rem;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.panel {
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+button,
+.button,
+input[type='radio'],
+input[type='checkbox'] {
+  cursor: pointer;
+}
+
+button,
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: #fff;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:disabled,
+.button.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button:not(:disabled):hover,
+.button:not(.disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.upload-zone {
+  border: 2px dashed #cbd5e1;
+  padding: 1.5rem;
+  border-radius: 16px;
+  text-align: center;
+  background: #f8fafc;
+}
+
+.upload-zone .drop-area.dragging {
+  border-color: #38bdf8;
+  background-color: rgba(56, 189, 248, 0.15);
+}
+
+.document-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.document-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+  background-color: #fdfdfd;
+  transition: border-color 0.2s ease;
+}
+
+.document-item.status-ready {
+  border-color: #22c55e;
+}
+
+.document-item.status-processing {
+  border-color: #f97316;
+}
+
+.document-title {
+  margin: 0 0 0.5rem 0;
+  font-weight: 600;
+}
+
+.document-meta {
+  margin: 0;
+  color: #475569;
+}
+
+.error-message {
+  color: #dc2626;
+}
+
+.reader-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.reader-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.reader-header button {
+  margin-right: 0.5rem;
+}
+
+.reader-tools {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reader {
+  display: grid;
+  gap: 1rem;
+}
+
+.reader.split {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.reader.single {
+  grid-template-columns: 1fr;
+}
+
+.reader-column {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-list li {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.75rem;
+  background-color: #f8fafc;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.section-list li.active {
+  border-color: #2563eb;
+  background-color: rgba(37, 99, 235, 0.1);
+}
+
+.reader-insights {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem 1.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.reader-insights ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 16px;
+  max-width: 520px;
+  width: 100%;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal textarea {
+  resize: vertical;
+  min-height: 80px;
+  border-radius: 12px;
+  border: 1px solid #d0d5dd;
+  padding: 0.75rem;
+}
+
+.close-button {
+  background: transparent;
+  color: #1c1f23;
+  font-size: 1.5rem;
+}
+
+.qa-answer {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+.qa-sources ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.qa-sources button {
+  background: #2563eb;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+}
+
+.export-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.export-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.export-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.restore-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.hint {
+  color: #64748b;
+  font-size: 0.9rem;
+}

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ProstePrawo</title>
+    <link rel="stylesheet" href="/assets/app.css" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      const e = React.createElement;
+      function PlaceholderApp() {
+        return e(
+          'div',
+          { className: 'app-shell', style: { padding: '2rem' } },
+          [
+            e('h1', { key: 'title', className: 'app-logo' }, 'ProstePrawo'),
+            e(
+              'p',
+              { key: 'message', style: { marginTop: '1rem', fontSize: '1.1rem' } },
+              'Statyczna wersja interfejsu została zbudowana bez zależności npm ze względu na ograniczenia środowiska.'
+            ),
+          ]
+        );
+      }
+      ReactDOM.createRoot(document.getElementById('root')).render(e(PlaceholderApp));
+    </script>
+  </body>
+</html>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,1 +1,2 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api';


### PR DESCRIPTION
## Summary
- mount the prebuilt frontend under FastAPI with an SPA-friendly fallback and expose the API under `/api`
- point the frontend client to the new base path and ship placeholder build artefacts
- copy the compiled frontend into the backend image by updating the Dockerfile and compose context

## Testing
- pytest
- npm run build *(fails: vite: not found in sandboxed environment)*
- uvicorn app.main:app --reload *(fails: uvicorn not available in sandbox)*
- docker-compose build backend *(fails: docker-compose unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e01cc2e7ac8326988bf7f4c3f92175