### PR TITLE
Improve frontend asset discovery for container deployments

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,20 @@ from __future__ import annotations
 
 from pathlib import Path
 
+
+def _discover_project_root(start_path: Path | None = None) -> Path:
+    """Return the repository root that contains the built frontend assets."""
+
+    current = (start_path or Path(__file__).resolve())
+    if current.is_file():
+        current = current.parent
+
+    for directory in [current, *current.parents]:
+        if (directory / "frontend" / "dist").exists():
+            return directory.resolve()
+
+    return Path(__file__).resolve().parents[2]
+
 from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -12,7 +26,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from .api.routes import documents, health
 
 
-BASE_DIR = Path(__file__).resolve().parents[2]
+BASE_DIR = _discover_project_root()
 FRONTEND_DIST_DIR = (BASE_DIR / "frontend" / "dist").resolve()
 INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+pytest.importorskip("fastapi")
+
+from app.main import _discover_project_root
+
+
+def test_discover_project_root_supports_container_layout(tmp_path):
+    container_root = tmp_path / "app"
+    backend_dir = container_root / "app"
+    frontend_dist = container_root / "frontend" / "dist"
+
+    frontend_dist.mkdir(parents=True)
+    backend_dir.mkdir(parents=True)
+
+    fake_main = backend_dir / "main.py"
+    fake_main.write_text("# fake main module\n")
+
+    discovered_root = _discover_project_root(fake_main)
+
+    assert discovered_root == container_root.resolve()
+    assert (discovered_root / "frontend" / "dist").resolve() == frontend_dist.resolve()


### PR DESCRIPTION
## Summary
- add a helper that resolves the project root by scanning for the frontend build directory
- use the discovered root when serving SPA assets so both repo and container layouts work
- add a unit test that simulates the container directory structure

## Testing
- pytest backend/tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68e0218185fc8326a1bf5541571e57e4