### PR TITLE
feat(frontend): add interactive static PoC UI

### DIFF
--- a/frontend/dist/assets/app.css
+++ b/frontend/dist/assets/app.css
@@ -9,6 +9,10 @@ body {
   background-color: #f7f9fb;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 .app-shell {
   min-height: 100vh;
   display: flex;
@@ -36,6 +40,7 @@ body {
   margin-left: 1rem;
   color: #d9e2ec;
   text-decoration: none;
+  font-weight: 500;
 }
 
 .app-header nav a.active,
@@ -50,51 +55,102 @@ body {
   max-width: 1200px;
   width: 100%;
   margin: 0 auto;
-  box-sizing: border-box;
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.dashboard-metrics div {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.12));
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.metric-number {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.metric-label {
+  font-size: 0.9rem;
+  color: #475569;
 }
 
 .panel {
   background-color: #fff;
   border-radius: 16px;
   padding: 1.5rem;
-  margin-bottom: 1.5rem;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.panel + .panel {
+  margin-top: 1.5rem;
 }
 
 .panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel-subtitle {
+  margin: 0.35rem 0 0;
+  color: #64748b;
+  font-size: 0.95rem;
 }
 
 button,
 .button,
+.button-link,
+select,
+textarea,
 input[type='radio'],
 input[type='checkbox'] {
   cursor: pointer;
+  font-family: inherit;
 }
 
 button,
-.button {
+.button,
+.button-link {
   border: none;
   border-radius: 999px;
   padding: 0.6rem 1.2rem;
   background: linear-gradient(135deg, #2563eb, #38bdf8);
   color: #fff;
   font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 button:disabled,
-.button.disabled {
+.button.disabled,
+.button-link.disabled {
   opacity: 0.6;
   cursor: not-allowed;
   box-shadow: none;
 }
 
 button:not(:disabled):hover,
-.button:not(.disabled):hover {
+.button:not(.disabled):hover,
+.button-link:not(.disabled):hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
 }
@@ -107,9 +163,36 @@ button:not(:disabled):hover,
   background: #f8fafc;
 }
 
+.upload-zone .drop-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .upload-zone .drop-area.dragging {
-  border-color: #38bdf8;
+  border-radius: 12px;
+  padding: 0.5rem;
   background-color: rgba(56, 189, 248, 0.15);
+}
+
+.upload-title {
+  font-weight: 600;
+  margin: 0;
+}
+
+.upload-hint,
+.hint {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.empty-state {
+  color: #475569;
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 1rem;
 }
 
 .document-list {
@@ -129,25 +212,71 @@ button:not(:disabled):hover,
   border-radius: 12px;
   padding: 1rem;
   background-color: #fdfdfd;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.document-item.status-ready {
-  border-color: #22c55e;
+.document-item:hover {
+  border-color: #2563eb;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.08);
 }
 
-.document-item.status-processing {
-  border-color: #f97316;
+.document-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .document-title {
-  margin: 0 0 0.5rem 0;
+  margin: 0;
   font-weight: 600;
+  font-size: 1.05rem;
 }
 
 .document-meta {
   margin: 0;
   color: #475569;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.document-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background-color: #e2e8f0;
+  color: #1f2937;
+}
+
+.status-ready {
+  background-color: rgba(34, 197, 94, 0.15);
+  color: #047857;
+}
+
+.status-processing {
+  background-color: rgba(249, 115, 22, 0.15);
+  color: #c2410c;
+}
+
+.status-received {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.status-failed {
+  background-color: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
 }
 
 .error-message {
@@ -162,18 +291,32 @@ button:not(:disabled):hover,
 .reader-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 1rem;
 }
 
-.reader-header button {
-  margin-right: 0.5rem;
+.reader-header h1 {
+  margin-bottom: 0.25rem;
 }
 
 .reader-tools {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #f1f5f9;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.switch input {
+  cursor: pointer;
 }
 
 .reader {
@@ -192,8 +335,12 @@ button:not(:disabled):hover,
 .reader-column {
   background: #fff;
   border-radius: 16px;
-  padding: 1rem;
+  padding: 1.25rem;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.reader-column h3 {
+  margin-top: 0;
 }
 
 .section-list {
@@ -218,14 +365,30 @@ button:not(:disabled):hover,
   background-color: rgba(37, 99, 235, 0.1);
 }
 
+.section-list li header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.section-excerpt {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
 .reader-insights {
   background: #fff;
   border-radius: 16px;
-  padding: 1rem 1.5rem;
+  padding: 1.25rem 1.5rem;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
 }
 
-.reader-insights ul {
+.insight-group ul {
   margin: 0;
   padding-left: 1.2rem;
 }
@@ -268,16 +431,18 @@ button:not(:disabled):hover,
 
 .modal textarea {
   resize: vertical;
-  min-height: 80px;
+  min-height: 90px;
   border-radius: 12px;
   border: 1px solid #d0d5dd;
   padding: 0.75rem;
+  font-family: inherit;
 }
 
 .close-button {
   background: transparent;
   color: #1c1f23;
   font-size: 1.5rem;
+  padding: 0;
 }
 
 .qa-answer {
@@ -300,6 +465,7 @@ button:not(:disabled):hover,
   color: #fff;
   border-radius: 999px;
   padding: 0.3rem 0.75rem;
+  border: none;
 }
 
 .export-page {
@@ -314,10 +480,19 @@ button:not(:disabled):hover,
   gap: 1rem;
 }
 
-.export-options {
+.select-field {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  font-weight: 500;
+}
+
+.select-field select {
+  border-radius: 12px;
+  border: 1px solid #d0d5dd;
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  background-color: #fff;
 }
 
 .restore-toggle {
@@ -327,7 +502,38 @@ button:not(:disabled):hover,
   margin-top: 1rem;
 }
 
-.hint {
-  color: #64748b;
-  font-size: 0.9rem;
+.status-message {
+  margin-top: 0.75rem;
+  color: #0f766e;
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .app-main {
+    padding: 1.5rem;
+  }
+
+  .reader-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .reader-tools {
+    flex-wrap: wrap;
+  }
+
+  .document-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .document-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .reader-insights {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -7,26 +7,848 @@
     <link rel="stylesheet" href="/assets/app.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script>
-      const e = React.createElement;
-      function PlaceholderApp() {
-        return e(
-          'div',
-          { className: 'app-shell', style: { padding: '2rem' } },
-          [
-            e('h1', { key: 'title', className: 'app-logo' }, 'ProstePrawo'),
-            e(
-              'p',
-              { key: 'message', style: { marginTop: '1rem', fontSize: '1.1rem' } },
-              'Statyczna wersja interfejsu została zbudowana bez zależności npm ze względu na ograniczenia środowiska.'
-            ),
+    <script type="text/babel" data-type="module" data-presets="env,react">
+      const {
+        useState,
+        useMemo,
+        useEffect,
+        useCallback,
+        useRef
+      } = React;
+      const {
+        BrowserRouter,
+        Routes,
+        Route,
+        Link,
+        NavLink,
+        useLocation,
+        useNavigate,
+        useParams
+      } = ReactRouterDOM;
+
+      const STATUS_LABELS = {
+        received: 'Odebrany',
+        processing: 'Przetwarzanie',
+        ready: 'Przetworzony',
+        failed: 'Błąd'
+      };
+
+      const INITIAL_DOCUMENTS = [
+        {
+          document_id: 'regulamin-2024',
+          title: 'Regulamin pracy 2024',
+          created_at: '2024-03-11T09:30:00.000Z',
+          status: 'ready',
+          summary:
+            'Zbiór zasad organizacji pracy i bezpieczeństwa przygotowany w nowej wersji na rok 2024.',
+          obligations: [
+            'Przekazać pracownikom harmonogram pracy i urlopów do 31 marca.',
+            'Zapewnić szkolenie BHP każdemu nowemu pracownikowi w ciągu 14 dni od zatrudnienia.'
+          ],
+          penalties: [
+            'Kary porządkowe zgodnie z art. 108 KP.',
+            'Możliwość rozwiązania umowy przy rażącym naruszeniu zasad BHP.'
+          ],
+          deadlines: [
+            'Przekazanie zmian w regulaminie do wiadomości zespołu w 7 dni od publikacji.',
+            'Przegląd sprzętu ochronnego co 6 miesięcy.'
+          ],
+          risks: [
+            'Ryzyko wypadków związanych z pracą na wysokości.',
+            'Ryzyko sankcji PIP w razie braku dokumentacji szkoleń.'
           ]
+        },
+        {
+          document_id: 'polityka-ochrony',
+          title: 'Polityka ochrony danych klientów',
+          created_at: '2024-03-18T13:05:00.000Z',
+          status: 'processing',
+          summary:
+            'Procedura przetwarzania danych osobowych w organizacji wraz z opisem ról i zgód.',
+          obligations: [
+            'Weryfikować podstawy prawne przetwarzania danych.',
+            'Prowadzić rejestr naruszeń w systemie zarządzania incydentami.'
+          ],
+          penalties: [
+            'Zawiadomienie PUODO oraz osób, których dane dotyczą.',
+            'Kary umowne dla podmiotów przetwarzających w razie braku procedur bezpieczeństwa.'
+          ],
+          deadlines: [
+            'Zgłoszenie naruszenia w ciągu 72 godzin od wykrycia.',
+            'Coroczny audyt bezpieczeństwa do końca listopada.'
+          ],
+          risks: [
+            'Ryzyko utraty reputacji przy braku reakcji na naruszenie.',
+            'Ryzyko sankcji administracyjnych do 20 mln EUR lub 4% obrotu.'
+          ]
+        },
+        {
+          document_id: 'umowa-b2b',
+          title: 'Umowa współpracy B2B',
+          created_at: '2024-03-22T08:10:00.000Z',
+          status: 'received',
+          summary: 'Projekt umowy ramowej z podwykonawcą IT.',
+          obligations: [
+            'Raportować postępy prac sprintów co 2 tygodnie.',
+            'Zapewnić zgodność z polityką bezpieczeństwa informacji klienta.'
+          ],
+          penalties: ['Kary umowne 500 PLN za każdy dzień opóźnienia.', 'Możliwość wypowiedzenia umowy z miesięcznym okresem wypowiedzenia.'],
+          deadlines: ['Przekazanie harmonogramu wdrożenia przed startem projektu.', 'Faktura końcowa 7 dni po akceptacji odbioru.'],
+          risks: ['Ryzyko opóźnień wdrożeniowych przy zmianach zakresu.', 'Ryzyko braku dostępności specjalistów po stronie dostawcy.']
+        }
+      ];
+
+      const INITIAL_SECTIONS = {
+        'regulamin-2024': [
+          {
+            identifier: 'Art. 5 § 2',
+            source_excerpt:
+              'Pracodawca zapewnia środki ochrony indywidualnej adekwatne do zidentyfikowanych zagrożeń.',
+            source_text:
+              '§ 2. Pracodawca jest zobowiązany wyposażyć pracowników w środki ochrony indywidualnej oraz prowadzić ich ewidencję. Środki te muszą być zgodne z obowiązującymi normami bezpieczeństwa.',
+            plain_language:
+              'Pracodawca musi dać pracownikom odpowiednie kaski, rękawice i inne środki ochrony. Musi też prowadzić listę wydanych elementów.'
+          },
+          {
+            identifier: 'Art. 8 § 1',
+            source_excerpt:
+              'Szkolenie wstępne BHP należy przeprowadzić przed dopuszczeniem do pracy.',
+            source_text:
+              '§ 1. Każdy nowo zatrudniony pracownik przed rozpoczęciem pracy jest obowiązany odbyć szkolenie wstępne z zakresu bezpieczeństwa i higieny pracy.',
+            plain_language:
+              'Nowa osoba w zespole musi odbyć szkolenie BHP zanim zacznie wykonywać obowiązki.'
+          },
+          {
+            identifier: '§ 12 ust. 3',
+            source_excerpt: 'Pracownik potwierdza zapoznanie z regulaminem podpisem.',
+            source_text:
+              'Ust. 3. Każdy pracownik potwierdza zapoznanie się z regulaminem pracy poprzez złożenie podpisu na liście obecności.',
+            plain_language:
+              'Pracownik musi podpisać się na liście, że zna regulamin. Jest to dowód na przeprowadzenie komunikacji.'
+          }
+        ],
+        'polityka-ochrony': [
+          {
+            identifier: 'Rozdział 2 § 4',
+            source_excerpt: 'Administrator wyznacza Inspektora Ochrony Danych.',
+            source_text:
+              'Administrator danych powołuje inspektora ochrony danych, który odpowiada za nadzór nad przestrzeganiem przepisów RODO w organizacji.',
+            plain_language:
+              'Firma musi mieć osobę pilnującą zasad ochrony danych. To ona sprawdza, czy wszyscy działają zgodnie z RODO.'
+          },
+          {
+            identifier: 'Rozdział 4 § 9',
+            source_excerpt: 'Każdy incydent należy zgłosić do 72 godzin.',
+            source_text:
+              'W przypadku naruszenia ochrony danych osobowych administrator zgłasza incydent organowi nadzorczemu w terminie 72 godzin.',
+            plain_language:
+              'Jeśli dojdzie do wycieku danych, firma ma maksymalnie 3 dni na zgłoszenie tego do urzędu.'
+          }
+        ],
+        'umowa-b2b': [
+          {
+            identifier: '§ 5 pkt 1',
+            source_excerpt: 'Wynagrodzenie ustala się według stawki godzinowej.',
+            source_text:
+              'Strony uzgadniają wynagrodzenie wykonawcy według stawki 180 PLN netto za każdą przepracowaną godzinę w danym miesiącu kalendarzowym.',
+            plain_language:
+              'Podwykonawca rozlicza się godzinowo po 180 PLN za każdą przepracowaną godzinę.'
+          },
+          {
+            identifier: '§ 9 pkt 4',
+            source_excerpt: 'Strony stosują 30-dniowy okres wypowiedzenia.',
+            source_text:
+              'Każda ze stron może rozwiązać umowę z zachowaniem 30-dniowego okresu wypowiedzenia ze skutkiem na koniec miesiąca kalendarzowego.',
+            plain_language:
+              'Jeśli ktoś chce zakończyć współpracę, musi to zgłosić miesiąc wcześniej i pracować do końca miesiąca.'
+          }
+        ]
+      };
+
+      function createGeneratedSections(title, documentId) {
+        const baseLabel = title || 'Dokument';
+        return [
+          {
+            identifier: `${documentId.toUpperCase()} § 1`,
+            source_excerpt: `${baseLabel} – wprowadzenie do dokumentu.`,
+            source_text:
+              `Dokument ${baseLabel} opisuje podstawowe zasady współpracy. Obejmuje zakres odpowiedzialności stron oraz wymagania co do raportowania postępów.`,
+            plain_language:
+              `Ten dokument opisuje jak współpracować i jak raportować postępy. To szybki zarys zasad zapisanych w oryginale.`
+          },
+          {
+            identifier: `${documentId.toUpperCase()} § 2`,
+            source_excerpt: 'Przypomnienie o terminach i raportowaniu.',
+            source_text:
+              'Strony uzgadniają przekazywanie raportu co dwa tygodnie oraz zgłaszanie ryzyk biznesowych niezwłocznie po ich wykryciu.',
+            plain_language:
+              'Co dwa tygodnie trzeba przesłać krótkie podsumowanie działań. Każde ryzyko należy zgłosić od razu.'
+          }
+        ];
+      }
+
+      function getQaAnswer(question, document, sections) {
+        const normalized = question.trim().toLowerCase();
+        const bank = [
+          {
+            keywords: ['obowiązk', 'powinn'],
+            template:
+              'Twoje najważniejsze obowiązki to zapewnienie środków ochrony oraz szkolenie zespołu. Źródła: Art. 5 § 2, Art. 8 § 1'
+          },
+          {
+            keywords: ['kara', 'sankc'],
+            template:
+              'Naruszenie zasad może skutkować karą porządkową lub rozwiązaniem umowy. Źródła: § 12 ust. 3'
+          },
+          {
+            keywords: ['termin', 'deadline'],
+            template:
+              'Kluczowe terminy to zgłoszenie zmian w 7 dni i szkolenie BHP przed rozpoczęciem pracy. Źródła: Art. 8 § 1'
+          },
+          {
+            keywords: ['pii', 'danych'],
+            template:
+              'Dane osobowe muszą być zabezpieczone, a incydenty zgłaszane w 72 h. Źródła: Rozdział 4 § 9'
+          }
+        ];
+
+        for (const item of bank) {
+          if (item.keywords.some((keyword) => normalized.includes(keyword))) {
+            return item.template;
+          }
+        }
+
+        const fallbackSource = sections[0] ? sections[0].identifier : 'Art. 1';
+        return `Nie znaleziono dedykowanej odpowiedzi. Zapoznaj się z kluczowymi fragmentami dokumentu. Źródła: ${fallbackSource}`;
+      }
+
+      function extractSources(answer) {
+        const marker = 'Źródła:';
+        const index = answer.indexOf(marker);
+        if (index === -1) {
+          return [];
+        }
+        return answer
+          .slice(index + marker.length)
+          .split(/[,•]/)
+          .map((item) => item.trim())
+          .filter((item) => item.length > 0);
+      }
+
+      function UploadZone({ onUploadComplete }) {
+        const ACCEPTED_TYPES = ['.pdf', '.docx', '.txt', '.md'];
+        const fileInputRef = useRef(null);
+        const [isDragging, setIsDragging] = useState(false);
+        const [isUploading, setIsUploading] = useState(false);
+        const [error, setError] = useState(null);
+
+        const handleFiles = useCallback(
+          (files) => {
+            if (!files || files.length === 0) {
+              return;
+            }
+            const file = files[0];
+            setIsUploading(true);
+            setError(null);
+            setTimeout(() => {
+              const docId = `demo-${Math.random().toString(36).slice(2, 7)}`;
+              const title = file.name.replace(/\.[^.]+$/, '') || 'Nowy dokument';
+              onUploadComplete({
+                document_id: docId,
+                title,
+                created_at: new Date().toISOString(),
+                status: 'processing',
+                summary: `Szybka analiza dokumentu ${title}.`,
+                obligations: [],
+                penalties: [],
+                deadlines: [],
+                risks: []
+              });
+              setIsUploading(false);
+              if (fileInputRef.current) {
+                fileInputRef.current.value = '';
+              }
+            }, 600);
+          },
+          [onUploadComplete]
+        );
+
+        const handleDrop = useCallback(
+          (event) => {
+            event.preventDefault();
+            setIsDragging(false);
+            handleFiles(event.dataTransfer.files);
+          },
+          [handleFiles]
+        );
+
+        const handleSelect = useCallback(() => {
+          handleFiles(fileInputRef.current ? fileInputRef.current.files : null);
+        }, [handleFiles]);
+
+        return (
+          <div className="upload-zone">
+            <div
+              className={`drop-area ${isDragging ? 'dragging' : ''}`}
+              onDragOver={(event) => {
+                event.preventDefault();
+                setIsDragging(true);
+              }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleDrop}
+            >
+              <p className="upload-title">Przeciągnij plik lub wybierz z dysku</p>
+              <p className="upload-hint">Obsługiwane formaty: {ACCEPTED_TYPES.join(', ')}</p>
+              <button type="button" onClick={() => fileInputRef.current && fileInputRef.current.click()} disabled={isUploading}>
+                {isUploading ? 'Przesyłanie...' : 'Wybierz plik'}
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={ACCEPTED_TYPES.join(',')}
+                hidden
+                onChange={handleSelect}
+              />
+            </div>
+            {error && <p className="error-message">{error}</p>}
+          </div>
         );
       }
-      ReactDOM.createRoot(document.getElementById('root')).render(e(PlaceholderApp));
+
+      function DocumentList({ documents, isLoading, onRefresh }) {
+        return (
+          <section className="panel">
+            <header className="panel-header">
+              <div>
+                <h2>Twoje dokumenty</h2>
+                <p className="panel-subtitle">Monitoruj status przetwarzania i otwieraj gotowe opracowania.</p>
+              </div>
+              <button type="button" onClick={onRefresh} disabled={isLoading}>
+                {isLoading ? 'Odświeżanie...' : 'Odśwież'}
+              </button>
+            </header>
+            {documents.length === 0 ? (
+              <p className="empty-state">Brak dokumentów. Prześlij plik, aby rozpocząć analizę.</p>
+            ) : (
+              <ul className="document-list">
+                {documents.map((document) => (
+                  <li key={document.document_id} className={`document-item status-${document.status}`}>
+                    <div className="document-info">
+                      <p className="document-title">{document.title}</p>
+                      <p className="document-meta">
+                        <span>#{document.document_id}</span>
+                        <span>Dodano: {new Date(document.created_at).toLocaleString('pl-PL')}</span>
+                      </p>
+                    </div>
+                    <div className="document-actions">
+                      <span className={`status-badge status-${document.status}`}>{STATUS_LABELS[document.status] || document.status}</span>
+                      <Link to={`/documents/${document.document_id}`} className="button-link">
+                        Otwórz
+                      </Link>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        );
+      }
+
+      function SectionViewer({ sections, activeIdentifier, sideBySide, onSelect }) {
+        if (!sections || sections.length === 0) {
+          return <p>Brak uproszczonych sekcji dla tego dokumentu.</p>;
+        }
+
+        if (sideBySide) {
+          return (
+            <div className="reader split">
+              <div className="reader-column">
+                <h3>Oryginał</h3>
+                <ul className="section-list">
+                  {sections.map((section) => (
+                    <li
+                      key={section.identifier}
+                      className={section.identifier === activeIdentifier ? 'active' : ''}
+                      data-section-id={section.identifier}
+                      onClick={() => onSelect(section.identifier)}
+                    >
+                      <header>
+                        <strong>{section.identifier}</strong>
+                        <p className="section-excerpt">{section.source_excerpt}</p>
+                      </header>
+                      <p>{section.source_text}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="reader-column">
+                <h3>W prostych słowach</h3>
+                <ul className="section-list">
+                  {sections.map((section) => (
+                    <li
+                      key={`${section.identifier}-plain`}
+                      className={section.identifier === activeIdentifier ? 'active' : ''}
+                      data-section-id={section.identifier}
+                    >
+                      <header>
+                        <strong>{section.identifier}</strong>
+                      </header>
+                      <p>{section.plain_language}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          );
+        }
+
+        return (
+          <div className="reader single">
+            <div className="reader-column">
+              <h3>W prostych słowach</h3>
+              <ul className="section-list">
+                {sections.map((section) => (
+                  <li
+                    key={`${section.identifier}-solo`}
+                    className={section.identifier === activeIdentifier ? 'active' : ''}
+                    data-section-id={section.identifier}
+                    onClick={() => onSelect(section.identifier)}
+                  >
+                    <header>
+                      <strong>{section.identifier}</strong>
+                    </header>
+                    <p>{section.plain_language}</p>
+                    <details>
+                      <summary>Fragment oryginału</summary>
+                      <p>{section.source_text}</p>
+                    </details>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        );
+      }
+
+      function QaModal({ document, sections, onClose, onHighlightSource }) {
+        const [question, setQuestion] = useState('Jakie mam obowiązki?');
+        const [answer, setAnswer] = useState('');
+        const [isLoading, setIsLoading] = useState(false);
+        const [error, setError] = useState(null);
+
+        const sources = useMemo(() => extractSources(answer), [answer]);
+
+        const askQuestion = useCallback(() => {
+          if (!question.trim()) {
+            setError('Zadaj pytanie, aby otrzymać odpowiedź.');
+            return;
+          }
+          setError(null);
+          setIsLoading(true);
+          setTimeout(() => {
+            const generated = getQaAnswer(question, document, sections);
+            setAnswer(generated);
+            setIsLoading(false);
+          }, 500);
+        }, [question, document, sections]);
+
+        return (
+          <div className="modal-backdrop" role="dialog" aria-modal="true">
+            <div className="modal">
+              <header className="modal-header">
+                <h2>Zapytaj dokument</h2>
+                <button type="button" onClick={onClose} className="close-button" aria-label="Zamknij">
+                  ×
+                </button>
+              </header>
+              <div className="modal-content">
+                <label htmlFor="qa-question">Pytanie</label>
+                <textarea
+                  id="qa-question"
+                  value={question}
+                  onChange={(event) => setQuestion(event.target.value)}
+                  rows={3}
+                  placeholder="Opisz czego chcesz się dowiedzieć..."
+                />
+                <button type="button" onClick={askQuestion} disabled={isLoading}>
+                  {isLoading ? 'Szukanie...' : 'Szukaj odpowiedzi'}
+                </button>
+                {error && <p className="error-message">{error}</p>}
+                {answer && (
+                  <div className="qa-answer">
+                    <p>{answer}</p>
+                    {sources.length > 0 && (
+                      <div className="qa-sources">
+                        <strong>Źródła:</strong>
+                        <ul>
+                          {sources.map((source) => (
+                            <li key={source}>
+                              <button type="button" onClick={() => onHighlightSource(source)}>
+                                {source}
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      function DashboardPage({ documents, onUploadComplete, onRefresh }) {
+        const [isRefreshing, setIsRefreshing] = useState(false);
+
+        const readyCount = useMemo(
+          () => documents.filter((item) => item.status === 'ready').length,
+          [documents]
+        );
+
+        const handleRefresh = useCallback(() => {
+          setIsRefreshing(true);
+          setTimeout(() => {
+            onRefresh();
+            setIsRefreshing(false);
+          }, 500);
+        }, [onRefresh]);
+
+        return (
+          <div className="dashboard">
+            <section className="panel">
+              <h1>Panel dokumentów</h1>
+              <p>
+                Prześlij dokument, aby uruchomić przetwarzanie. Analiza jest symulowana lokalnie, więc odśwież listę,
+                aby zobaczyć aktualny status.
+              </p>
+              <UploadZone onUploadComplete={onUploadComplete} />
+              <div className="dashboard-metrics">
+                <div>
+                  <span className="metric-number">{documents.length}</span>
+                  <span className="metric-label">Wszystkie dokumenty</span>
+                </div>
+                <div>
+                  <span className="metric-number">{readyCount}</span>
+                  <span className="metric-label">Gotowe opracowania</span>
+                </div>
+              </div>
+            </section>
+            <DocumentList documents={documents} isLoading={isRefreshing} onRefresh={handleRefresh} />
+          </div>
+        );
+      }
+
+      function ReaderPage({ documents, sectionsMap }) {
+        const { documentId } = useParams();
+        const navigate = useNavigate();
+        const currentDocument = useMemo(
+          () => documents.find((item) => item.document_id === documentId),
+          [documents, documentId]
+        );
+        const sections = sectionsMap[documentId] || [];
+        const [sideBySide, setSideBySide] = useState(true);
+        const [activeSection, setActiveSection] = useState(sections[0] ? sections[0].identifier : null);
+        const [showQa, setShowQa] = useState(false);
+
+        useEffect(() => {
+          setActiveSection(sections.length > 0 ? sections[0].identifier : null);
+        }, [sections, documentId]);
+
+        useEffect(() => {
+          if (activeSection) {
+            const target = window.document.querySelector(
+              `[data-section-id="${CSS.escape(activeSection)}"]`
+            );
+            if (target) {
+              target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+          }
+        }, [activeSection, sideBySide, sections]);
+
+        if (!currentDocument) {
+          return (
+            <section className="panel">
+              <h1>Nie znaleziono dokumentu</h1>
+              <p>Sprawdź adres URL lub wróć do panelu głównego.</p>
+              <Link to="/" className="button-link">
+                Wróć do dashboardu
+              </Link>
+            </section>
+          );
+        }
+
+        const ready = currentDocument.status === 'ready';
+
+        return (
+          <div className="reader-page">
+            <header className="reader-header">
+              <div>
+                <button type="button" onClick={() => navigate(-1)}>
+                  ← Wróć
+                </button>
+                <h1>{currentDocument.title}</h1>
+                <p>Status: {STATUS_LABELS[currentDocument.status] || currentDocument.status}</p>
+              </div>
+              <div className="reader-tools">
+                <label className="switch">
+                  <input
+                    type="checkbox"
+                    checked={sideBySide}
+                    onChange={(event) => setSideBySide(event.target.checked)}
+                  />
+                  <span>{sideBySide ? 'Widok równoległy' : 'Tylko uproszczenie'}</span>
+                </label>
+                <button type="button" onClick={() => setShowQa(true)} disabled={!ready}>
+                  Q&amp;A
+                </button>
+                <Link to={`/documents/${currentDocument.document_id}/export`} className={`button-link ${ready ? '' : 'disabled'}`}>
+                  Eksport
+                </Link>
+              </div>
+            </header>
+            <section className="panel">
+              <h2>Podsumowanie</h2>
+              <p>{currentDocument.summary}</p>
+            </section>
+            <SectionViewer
+              sections={sections}
+              activeIdentifier={activeSection}
+              sideBySide={sideBySide}
+              onSelect={setActiveSection}
+            />
+            <aside className="reader-insights">
+              <h2>Najważniejsze informacje</h2>
+              <div className="insight-group">
+                <h3>Obowiązki</h3>
+                {currentDocument.obligations.length > 0 ? (
+                  <ul>
+                    {currentDocument.obligations.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>Brak danych.</p>
+                )}
+              </div>
+              <div className="insight-group">
+                <h3>Kary</h3>
+                {currentDocument.penalties.length > 0 ? (
+                  <ul>
+                    {currentDocument.penalties.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>Brak danych.</p>
+                )}
+              </div>
+              <div className="insight-group">
+                <h3>Terminy</h3>
+                {currentDocument.deadlines.length > 0 ? (
+                  <ul>
+                    {currentDocument.deadlines.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>Brak danych.</p>
+                )}
+              </div>
+              <div className="insight-group">
+                <h3>Ryzyka</h3>
+                {currentDocument.risks.length > 0 ? (
+                  <ul>
+                    {currentDocument.risks.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>Brak danych.</p>
+                )}
+              </div>
+            </aside>
+            {showQa && (
+              <QaModal
+                document={currentDocument}
+                sections={sections}
+                onClose={() => setShowQa(false)}
+                onHighlightSource={(identifier) => setActiveSection(identifier)}
+              />
+            )}
+          </div>
+        );
+      }
+
+      function ExportPage({ documents }) {
+        const { documentId } = useParams();
+        const navigate = useNavigate();
+        const currentDocument = useMemo(
+          () => documents.find((item) => item.document_id === documentId),
+          [documents, documentId]
+        );
+        const [format, setFormat] = useState('pdf');
+        const [restorePii, setRestorePii] = useState(false);
+        const [statusMessage, setStatusMessage] = useState('');
+        const [isGenerating, setIsGenerating] = useState(false);
+
+        const handleGenerate = useCallback(() => {
+          setIsGenerating(true);
+          setStatusMessage('Generowanie pliku (symulacja)...');
+          setTimeout(() => {
+            setStatusMessage(`Eksport ${format.toUpperCase()} gotowy. Możesz zapisać plik lokalnie.`);
+            setIsGenerating(false);
+          }, 800);
+        }, [format]);
+
+        if (!currentDocument) {
+          return (
+            <section className="panel">
+              <h1>Eksport</h1>
+              <p>Dokument nie istnieje lub został usunięty.</p>
+              <button type="button" onClick={() => navigate(-1)}>
+                Wróć
+              </button>
+            </section>
+          );
+        }
+
+        return (
+          <div className="export-page">
+            <header className="export-header">
+              <button type="button" onClick={() => navigate(-1)}>
+                ← Wróć do dokumentu
+              </button>
+              <div>
+                <h1>Eksport dokumentu</h1>
+                <p>{currentDocument.title}</p>
+              </div>
+            </header>
+            <section className="panel">
+              <h2>Wybierz format</h2>
+              <label className="select-field" htmlFor="export-format">
+                Format pliku
+                <select
+                  id="export-format"
+                  value={format}
+                  onChange={(event) => setFormat(event.target.value)}
+                >
+                  <option value="pdf">PDF (.pdf)</option>
+                  <option value="docx">Word (.docx)</option>
+                  <option value="markdown">Markdown (.md)</option>
+                </select>
+              </label>
+              <label className="restore-toggle">
+                <input
+                  type="checkbox"
+                  checked={restorePii}
+                  onChange={(event) => setRestorePii(event.target.checked)}
+                />
+                Przywróć PII w eksporcie (tylko lokalnie)
+              </label>
+              <p className="hint">
+                Zaznaczenie tej opcji odtworzy zanonimizowane dane w wygenerowanym pliku, jeśli mapa PII jest dostępna w
+                Twoim środowisku.
+              </p>
+              <button type="button" onClick={handleGenerate} disabled={isGenerating}>
+                {isGenerating ? 'Generowanie...' : 'Generuj'}
+              </button>
+              {statusMessage && <p className="status-message">{statusMessage}</p>}
+            </section>
+          </div>
+        );
+      }
+
+      function NotFoundPage() {
+        return (
+          <section className="panel">
+            <h1>Nie znaleziono strony</h1>
+            <p>Sprawdź adres lub wróć do kokpitu dokumentów.</p>
+            <Link to="/" className="button-link">
+              Przejdź do dashboardu
+            </Link>
+          </section>
+        );
+      }
+
+      function AppShell() {
+        const location = useLocation();
+        const [documents, setDocuments] = useState(INITIAL_DOCUMENTS);
+        const [sectionsMap, setSectionsMap] = useState(INITIAL_SECTIONS);
+
+        const handleUploadComplete = useCallback((newDocument) => {
+          setDocuments((prev) => [newDocument, ...prev]);
+          setSectionsMap((prev) => ({
+            ...prev,
+            [newDocument.document_id]: prev[newDocument.document_id] || createGeneratedSections(newDocument.title, newDocument.document_id)
+          }));
+        }, []);
+
+        const handleRefreshStatuses = useCallback(() => {
+          setDocuments((prev) =>
+            prev.map((doc) => {
+              if (doc.status === 'received') {
+                return { ...doc, status: 'processing' };
+              }
+              if (doc.status === 'processing') {
+                return { ...doc, status: 'ready' };
+              }
+              return doc;
+            })
+          );
+        }, []);
+
+        return (
+          <div className="app-shell">
+            <header className="app-header">
+              <Link to="/" className="app-logo">
+                ProstePrawo
+              </Link>
+              <nav>
+                <NavLink to="/" className={({ isActive }) => (isActive && location.pathname === '/' ? 'active' : '')}>
+                  Dashboard
+                </NavLink>
+              </nav>
+            </header>
+            <main className="app-main">
+              <Routes>
+                <Route
+                  path="/"
+                  element={
+                    <DashboardPage
+                      documents={documents}
+                      onUploadComplete={handleUploadComplete}
+                      onRefresh={handleRefreshStatuses}
+                    />
+                  }
+                />
+                <Route
+                  path="/documents/:documentId"
+                  element={<ReaderPage documents={documents} sectionsMap={sectionsMap} />}
+                />
+                <Route
+                  path="/documents/:documentId/export"
+                  element={<ExportPage documents={documents} />}
+                />
+                <Route path="*" element={<NotFoundPage />} />
+              </Routes>
+            </main>
+          </div>
+        );
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(
+        <BrowserRouter>
+          <AppShell />
+        </BrowserRouter>
+      );
     </script>
   </body>
 </html>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -9,6 +9,10 @@ body {
   background-color: #f7f9fb;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 .app-shell {
   min-height: 100vh;
   display: flex;
@@ -36,6 +40,7 @@ body {
   margin-left: 1rem;
   color: #d9e2ec;
   text-decoration: none;
+  font-weight: 500;
 }
 
 .app-header nav a.active,
@@ -50,51 +55,102 @@ body {
   max-width: 1200px;
   width: 100%;
   margin: 0 auto;
-  box-sizing: border-box;
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.dashboard-metrics div {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.12));
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.metric-number {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.metric-label {
+  font-size: 0.9rem;
+  color: #475569;
 }
 
 .panel {
   background-color: #fff;
   border-radius: 16px;
   padding: 1.5rem;
-  margin-bottom: 1.5rem;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.panel + .panel {
+  margin-top: 1.5rem;
 }
 
 .panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel-subtitle {
+  margin: 0.35rem 0 0;
+  color: #64748b;
+  font-size: 0.95rem;
 }
 
 button,
 .button,
+.button-link,
+select,
+textarea,
 input[type='radio'],
 input[type='checkbox'] {
   cursor: pointer;
+  font-family: inherit;
 }
 
 button,
-.button {
+.button,
+.button-link {
   border: none;
   border-radius: 999px;
   padding: 0.6rem 1.2rem;
   background: linear-gradient(135deg, #2563eb, #38bdf8);
   color: #fff;
   font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 button:disabled,
-.button.disabled {
+.button.disabled,
+.button-link.disabled {
   opacity: 0.6;
   cursor: not-allowed;
   box-shadow: none;
 }
 
 button:not(:disabled):hover,
-.button:not(.disabled):hover {
+.button:not(.disabled):hover,
+.button-link:not(.disabled):hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
 }
@@ -107,9 +163,36 @@ button:not(:disabled):hover,
   background: #f8fafc;
 }
 
+.upload-zone .drop-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .upload-zone .drop-area.dragging {
-  border-color: #38bdf8;
+  border-radius: 12px;
+  padding: 0.5rem;
   background-color: rgba(56, 189, 248, 0.15);
+}
+
+.upload-title {
+  font-weight: 600;
+  margin: 0;
+}
+
+.upload-hint,
+.hint {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.empty-state {
+  color: #475569;
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 1rem;
 }
 
 .document-list {
@@ -129,25 +212,71 @@ button:not(:disabled):hover,
   border-radius: 12px;
   padding: 1rem;
   background-color: #fdfdfd;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.document-item.status-ready {
-  border-color: #22c55e;
+.document-item:hover {
+  border-color: #2563eb;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.08);
 }
 
-.document-item.status-processing {
-  border-color: #f97316;
+.document-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .document-title {
-  margin: 0 0 0.5rem 0;
+  margin: 0;
   font-weight: 600;
+  font-size: 1.05rem;
 }
 
 .document-meta {
   margin: 0;
   color: #475569;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.document-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background-color: #e2e8f0;
+  color: #1f2937;
+}
+
+.status-ready {
+  background-color: rgba(34, 197, 94, 0.15);
+  color: #047857;
+}
+
+.status-processing {
+  background-color: rgba(249, 115, 22, 0.15);
+  color: #c2410c;
+}
+
+.status-received {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.status-failed {
+  background-color: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
 }
 
 .error-message {
@@ -162,18 +291,32 @@ button:not(:disabled):hover,
 .reader-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 1rem;
 }
 
-.reader-header button {
-  margin-right: 0.5rem;
+.reader-header h1 {
+  margin-bottom: 0.25rem;
 }
 
 .reader-tools {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #f1f5f9;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.switch input {
+  cursor: pointer;
 }
 
 .reader {
@@ -192,8 +335,12 @@ button:not(:disabled):hover,
 .reader-column {
   background: #fff;
   border-radius: 16px;
-  padding: 1rem;
+  padding: 1.25rem;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.reader-column h3 {
+  margin-top: 0;
 }
 
 .section-list {
@@ -218,14 +365,30 @@ button:not(:disabled):hover,
   background-color: rgba(37, 99, 235, 0.1);
 }
 
+.section-list li header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.section-excerpt {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
 .reader-insights {
   background: #fff;
   border-radius: 16px;
-  padding: 1rem 1.5rem;
+  padding: 1.25rem 1.5rem;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
 }
 
-.reader-insights ul {
+.insight-group ul {
   margin: 0;
   padding-left: 1.2rem;
 }
@@ -268,16 +431,18 @@ button:not(:disabled):hover,
 
 .modal textarea {
   resize: vertical;
-  min-height: 80px;
+  min-height: 90px;
   border-radius: 12px;
   border: 1px solid #d0d5dd;
   padding: 0.75rem;
+  font-family: inherit;
 }
 
 .close-button {
   background: transparent;
   color: #1c1f23;
   font-size: 1.5rem;
+  padding: 0;
 }
 
 .qa-answer {
@@ -300,6 +465,7 @@ button:not(:disabled):hover,
   color: #fff;
   border-radius: 999px;
   padding: 0.3rem 0.75rem;
+  border: none;
 }
 
 .export-page {
@@ -314,10 +480,19 @@ button:not(:disabled):hover,
   gap: 1rem;
 }
 
-.export-options {
+.select-field {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  font-weight: 500;
+}
+
+.select-field select {
+  border-radius: 12px;
+  border: 1px solid #d0d5dd;
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  background-color: #fff;
 }
 
 .restore-toggle {
@@ -327,7 +502,38 @@ button:not(:disabled):hover,
   margin-top: 1rem;
 }
 
-.hint {
-  color: #64748b;
-  font-size: 0.9rem;
+.status-message {
+  margin-top: 0.75rem;
+  color: #0f766e;
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .app-main {
+    padding: 1.5rem;
+  }
+
+  .reader-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .reader-tools {
+    flex-wrap: wrap;
+  }
+
+  .document-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .document-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .reader-insights {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the static placeholder in dist with an interactive React-based proof of concept matching the dashboard, reader, Q&A, and export views
- add mocked document data, simplified section viewer, Q&A simulation, and export controls to showcase the PoC flows without a build step
- refresh shared styles to support the richer layout, status badges, metrics, and responsive behaviour

## Testing
- not run (static frontend only)


------
https://chatgpt.com/codex/tasks/task_e_68e0231c9e8c8326b71487d42fac217e