### PR TITLE
fix: ensure react-router scripts load

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -7,12 +7,15 @@
     <link rel="stylesheet" href="/assets/app.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js"></script>
+    <script src="https://unpkg.com/history@5.3.0/umd/history.production.min.js"></script>
+    <script src="https://unpkg.com/react-router@6.0.2/umd/react-router.production.min.js"></script>
+    <script src="https://unpkg.com/react-router-dom@6.0.2/umd/react-router-dom.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
     <script type="text/babel" data-type="module" data-presets="env,react">
+      function renderApp(ReactRouterDOM) {
       const {
         useState,
         useMemo,
@@ -849,6 +852,17 @@
           <AppShell />
         </BrowserRouter>
       );
+      }
+
+      const runWhenReady = () => {
+        if (window.ReactRouterDOM) {
+          renderApp(window.ReactRouterDOM);
+        } else {
+          setTimeout(runWhenReady, 50);
+        }
+      };
+
+      runWhenReady();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the history, react-router, and react-router-dom UMD bundles without crossorigin to avoid blocked CDN requests
- wrap the inline Babel app bootstrapping logic so it waits for React Router globals before rendering

## Testing
- playwright smoke check of the built dashboard

------
https://chatgpt.com/codex/tasks/task_e_68e0306daff08326a0723d9e6cd10054