### PR TITLE
Add PyPDF2 PDF extraction fallback

### DIFF
--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -34,8 +34,8 @@ def extract_document(path: Path) -> ExtractedDocument:
     operate in the test environment without heavyweight OCR dependencies.  For
     plain-text sources we simply decode the bytes using UTF-8 with fallback to
     latin-1.  For binary formats such as PDF we attempt a best-effort text
-    extraction using PyMuPDF when available; otherwise we fall back to decoding
-    whatever text layer may already be present in the file.
+    extraction using PyMuPDF when available, fall back to PyPDF2 when it is
+    installed, and only decode raw bytes if both strategies fail.
     """
 
     content = _read_text(path)
@@ -58,6 +58,20 @@ def _read_text(path: Path) -> str:
             finally:
                 doc.close()
         except Exception:  # pragma: no cover - import and runtime fallback
+            pass
+        try:
+            from PyPDF2 import PdfReader
+
+            reader = PdfReader(str(path))
+            text_chunks: list[str] = []
+            for page in reader.pages:
+                page_text = page.extract_text() or ""
+                if page_text:
+                    text_chunks.append(page_text.strip())
+            if text_chunks:
+                return "\n".join(text_chunks)
+            return ""
+        except Exception:
             pass
     raw_bytes = path.read_bytes()
     try:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
 pydantic>=2.7,<3.0
+PyPDF2>=3.0,<4.0
 pydantic-settings>=2.0,<3.0

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import asyncio
-import os
+import base64
 import json
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -14,6 +15,29 @@ import pytest
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+_PDF_SAMPLE_BASE64 = (
+    "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4K"
+    "ZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4K"
+    "ZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAg"
+    "MCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVu"
+    "dHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUx"
+    "IC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNTcgPj4K"
+    "c3RyZWFtCkJUIC9GMSAyNCBUZiA3MiA3MjAgVGQgKFRoaXMgaXMgYSB0aW55IFBERiBzYW1wbGUu"
+    "KSBUaiBFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAw"
+    "MDAwMDAxNSAwMDAwMCBuIAowMDAwMDAwMDY0IDAwMDAwIG4gCjAwMDAwMDAxMjEgMDAwMDAgbiAK"
+    "MDAwMDAwMDI0NyAwMDAwMCBuIAowMDAwMDAwMzE3IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUg"
+    "NiAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKNDI0CiUlRU9GCg=="
+)
+
+
+@pytest.fixture()
+def pdf_with_text(tmp_path: Path) -> Path:
+    pdf_bytes = base64.b64decode(_PDF_SAMPLE_BASE64)
+    path = tmp_path / "sample.pdf"
+    path.write_bytes(pdf_bytes)
+    return path
 
 
 def test_section_numbering_starts_at_one(tmp_path):
@@ -112,6 +136,7 @@ def test_pipeline_persists_only_placeholders(tmp_path, monkeypatch):
         config.get_settings.cache_clear()
 
 
+
 @pytest.mark.skipif(os.name == "nt", reason="Windows does not support POSIX permission checks")
 def test_secure_artifacts_have_restrictive_permissions(tmp_path, monkeypatch):
     pytest.importorskip("pydantic")
@@ -145,3 +170,12 @@ def test_secure_artifacts_have_restrictive_permissions(tmp_path, monkeypatch):
         assert file_mode == 0o600
     finally:
         config.get_settings.cache_clear()
+
+def test_extract_document_reads_pdf_text(pdf_with_text: Path):
+    pytest.importorskip("PyPDF2")
+    from app.services import ingestion
+
+    extracted = ingestion.extract_document(pdf_with_text)
+
+    assert "This is a tiny PDF sample." in extracted.text
+    assert any("tiny PDF sample" in section.text for section in extracted.sections)


### PR DESCRIPTION
## Summary
- add PyPDF2 as a backend dependency and update the ingestion service to prefer it when PyMuPDF is unavailable
- provide a tiny embedded PDF fixture and test that validates text extraction from PDFs

## Testing
- pytest backend/tests/test_ingestion.py

------
https://chatgpt.com/codex/tasks/task_e_68e048dc37ec8326b79a506a180ab6d1