### PR TITLE
Integrate OpenAI-backed inference with pipeline fallbacks

### DIFF
--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -1,4 +1,4 @@
-"""Rule-based inference utilities used in lieu of the final LLM stage."""
+"""Rule-based inference utilities with optional OpenAI integration."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -6,9 +6,11 @@ import re
 import textwrap
 from typing import Iterable
 
+from ..core.config import get_settings
 from ..models.documents import DocumentDefinition, SectionSimplification
 from .indexing import RetrievedChunk
 from .ingestion import DocumentSection
+from .openai_client import OpenAIClientError, get_openai_client
 
 
 @dataclass(slots=True)
@@ -19,9 +21,13 @@ class QaAnswer:
     sources: list[str]
 
 
-def build_summary(text: str) -> str:
-    """Create a deterministic short summary from the sanitised text."""
+def _should_use_cloud(use_cloud: bool | None) -> bool:
+    if use_cloud is not None:
+        return use_cloud
+    return get_settings().enable_cloud_llm
 
+
+def _build_summary_local(text: str) -> str:
     paragraphs = [paragraph.strip() for paragraph in text.splitlines() if paragraph.strip()]
     if not paragraphs:
         return "Brak treści do podsumowania."
@@ -29,6 +35,20 @@ def build_summary(text: str) -> str:
     if len(first) > 280:
         first = first[:277] + "..."
     return first
+
+
+def build_summary(text: str, use_cloud: bool | None = None) -> str:
+    """Return a short summary, preferring OpenAI when available."""
+
+    if _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            summary = client.summarise(text)
+            if summary:
+                return summary
+        except OpenAIClientError:
+            pass
+    return _build_summary_local(text)
 
 
 def _collect_sentences(text: str, keywords: Iterable[str]) -> list[str]:
@@ -43,27 +63,75 @@ def _collect_sentences(text: str, keywords: Iterable[str]) -> list[str]:
     return sentences
 
 
-def extract_obligations(text: str) -> list[str]:
+def extract_obligations(text: str, use_cloud: bool | None = None) -> list[str]:
+    if _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            obligations = client.extract_items(text, "obowiązki")
+            if obligations:
+                return obligations
+        except OpenAIClientError:
+            pass
     return _collect_sentences(text, ["zobowiąz", "obowiąz", "należy"])
 
 
-def extract_penalties(text: str) -> list[str]:
+def extract_penalties(text: str, use_cloud: bool | None = None) -> list[str]:
+    if _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            penalties = client.extract_items(text, "kary lub sankcje")
+            if penalties:
+                return penalties
+        except OpenAIClientError:
+            pass
     return _collect_sentences(text, ["kara", "odpowiedzialn", "grzywna"])
 
 
-def extract_deadlines(text: str) -> list[str]:
+def extract_deadlines(text: str, use_cloud: bool | None = None) -> list[str]:
+    if _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            deadlines = client.extract_items(text, "terminy lub daty graniczne")
+            if deadlines:
+                return deadlines
+        except OpenAIClientError:
+            pass
     return _collect_sentences(text, ["termin", "dni", "miesiąc", "miesiac"])
 
 
-def extract_risks(text: str) -> list[str]:
+def extract_risks(text: str, use_cloud: bool | None = None) -> list[str]:
+    if _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            risks = client.extract_items(text, "ryzyka dla stron umowy")
+            if risks:
+                return risks
+        except OpenAIClientError:
+            pass
     return _collect_sentences(text, ["ryzyk", "zagroż", "niebezpiecz", "utrata", "szkody"])
 
 
-def answer_question(question: str, retrieved_chunks: list[RetrievedChunk]) -> QaAnswer:
+def answer_question(
+    question: str, retrieved_chunks: list[RetrievedChunk], use_cloud: bool | None = None
+) -> QaAnswer:
+    if _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            result = client.answer_question(question, retrieved_chunks)
+            content = str(result.get("answer", "")).strip()
+            if content:
+                sources = [str(source) for source in result.get("sources", []) if str(source).strip()]
+                return QaAnswer(content=content, sources=sources)
+        except OpenAIClientError:
+            pass
+    return _answer_question_local(question, retrieved_chunks)
+
+
+def _answer_question_local(question: str, retrieved_chunks: list[RetrievedChunk]) -> QaAnswer:
     if not retrieved_chunks:
         return QaAnswer(content="Brak danych pozwalających na udzielenie odpowiedzi.", sources=[])
     best = retrieved_chunks[0]
-    summary = build_summary(best.text)
+    summary = _build_summary_local(best.text)
     content = (
         f"Na podstawie sekcji '{best.identifier}' odpowiedź brzmi: {summary} "
         "(odpowiedź wygenerowana heurystycznie)."
@@ -98,9 +166,43 @@ _REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
 )
 
 
-def simplify_sections(sections: Iterable[DocumentSection]) -> list[SectionSimplification]:
-    """Generate naive plain-language explanations for document sections."""
+def simplify_sections(
+    sections: Iterable[DocumentSection], use_cloud: bool | None = None
+) -> list[SectionSimplification]:
+    """Generate plain-language explanations using OpenAI when enabled."""
 
+    section_list = list(sections)
+    if _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            ai_results = client.simplify_sections(section_list)
+            mapped = {section.identifier: section for section in section_list}
+            simplifications: list[SectionSimplification] = []
+            for item in ai_results:
+                identifier = item.get("identifier")
+                if not identifier:
+                    continue
+                identifier = str(identifier)
+                source_section = mapped.get(identifier)
+                source_text = source_section.text if source_section else ""
+                excerpt_raw = item.get("source_excerpt")
+                excerpt = str(excerpt_raw) if excerpt_raw is not None else ""
+                simplifications.append(
+                    SectionSimplification(
+                        identifier=identifier,
+                        source_excerpt=(excerpt or _create_excerpt(source_text)),
+                        source_text=source_text,
+                        plain_language=str(item.get("plain_language", "")),
+                    )
+                )
+            if simplifications:
+                return simplifications
+        except OpenAIClientError:
+            pass
+    return _simplify_sections_local(section_list)
+
+
+def _simplify_sections_local(sections: Iterable[DocumentSection]) -> list[SectionSimplification]:
     simplifications: list[SectionSimplification] = []
     for section in sections:
         plain_text = _simplify_text(section.text)

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -1,0 +1,198 @@
+"""Thin wrapper around the official OpenAI client used by the pipeline."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Any, Iterable
+
+from openai import OpenAI
+
+from ..core.config import get_settings
+from .indexing import RetrievedChunk
+from .ingestion import DocumentSection
+
+
+class OpenAIClientError(RuntimeError):
+    """Raised when the OpenAI client fails to generate a valid response."""
+
+
+class OpenAIClient:
+    """High-level helper exposing domain specific prompts."""
+
+    def __init__(self, client: OpenAI | None = None) -> None:
+        settings = get_settings()
+        self._client = client or OpenAI()
+        self._model = settings.openai_model
+
+    def summarise(self, text: str) -> str:
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Jesteś prawniczym asystentem, który tworzy krótkie streszczenia "
+                    "z zanonimizowanych dokumentów. Odpowiadaj zwięźle w języku polskim."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Streszcz poniższy tekst w maksymalnie 3 zdaniach. "
+                    "Tekst:\n\n" + text
+                ),
+            },
+        ]
+        return self._complete(messages, max_tokens=300)
+
+    def extract_items(self, text: str, category: str) -> list[str]:
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Jesteś prawniczym asystentem pomagającym sporządzić listy punktów "
+                    "na podstawie zanonimizowanych dokumentów. Zwracaj odpowiedź jako JSON."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Przeczytaj tekst i wypisz {category} jako listę krótkich zdań. "
+                    "Zwróć czystą tablicę JSON, np. [\"Pozycja\"]. "
+                    "Tekst:\n\n{body}".format(category=category, body=text)
+                ),
+            },
+        ]
+        data = self._complete_json(messages, max_tokens=400)
+        if not isinstance(data, list):
+            raise OpenAIClientError("Nieprawidłowy format odpowiedzi dla listy elementów.")
+        cleaned: list[str] = []
+        for item in data:
+            if not isinstance(item, str):
+                continue
+            value = item.strip()
+            if value:
+                cleaned.append(value)
+        return cleaned
+
+    def simplify_sections(self, sections: Iterable[DocumentSection]) -> list[dict[str, str]]:
+        payload = [
+            {
+                "identifier": section.identifier,
+                "text": section.text,
+            }
+            for section in sections
+        ]
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Jesteś asystentem, który tłumaczy zapisy prawne na prosty język. "
+                    "Zwracaj wynik jako tablicę JSON z polami identifier, plain_language i "
+                    "source_excerpt. Używaj języka polskiego."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Uprość każdą z sekcji dokumentu. Wejście w formacie JSON:\n\n"
+                    + json.dumps(payload, ensure_ascii=False)
+                ),
+            },
+        ]
+        data = self._complete_json(messages, max_tokens=1200)
+        if not isinstance(data, list):
+            raise OpenAIClientError("Oczekiwano tablicy z uproszczeniami sekcji.")
+        results: list[dict[str, str]] = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            identifier = str(item.get("identifier", "")).strip()
+            plain = str(item.get("plain_language", "")).strip()
+            excerpt = str(item.get("source_excerpt", "")).strip()
+            if identifier and plain:
+                results.append(
+                    {
+                        "identifier": identifier,
+                        "plain_language": plain,
+                        "source_excerpt": excerpt,
+                    }
+                )
+        if not results:
+            raise OpenAIClientError("Brak poprawnych uproszczeń w odpowiedzi LLM.")
+        return results
+
+    def answer_question(
+        self, question: str, retrieved_chunks: Iterable[RetrievedChunk]
+    ) -> dict[str, Any]:
+        context = [
+            {
+                "identifier": chunk.identifier,
+                "text": chunk.text,
+            }
+            for chunk in retrieved_chunks
+        ]
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Jesteś prawniczym asystentem odpowiadającym na pytania na podstawie "
+                    "zebranych fragmentów dokumentu. Jeśli brakuje danych, jasno to powiedz."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Odpowiedz na pytanie użytkownika korzystając wyłącznie z kontekstu. "
+                    "Zwróć JSON o strukturze {\"answer\": str, \"sources\": [str]}. "
+                    "Kontekst:\n\n"
+                    + json.dumps(context, ensure_ascii=False)
+                    + "\n\nPytanie:\n"
+                    + question
+                ),
+            },
+        ]
+        data = self._complete_json(messages, max_tokens=600)
+        if not isinstance(data, dict):
+            raise OpenAIClientError("Niepoprawny format odpowiedzi dla Q&A.")
+        answer = str(data.get("answer", "")).strip()
+        sources_data = data.get("sources", [])
+        if isinstance(sources_data, list):
+            sources = [str(item).strip() for item in sources_data if str(item).strip()]
+        else:
+            sources = []
+        if not answer:
+            raise OpenAIClientError("Brak treści odpowiedzi Q&A.")
+        return {"answer": answer, "sources": sources}
+
+    def _complete(self, messages: list[dict[str, str]], *, max_tokens: int = 512, temperature: float = 0.2) -> str:
+        try:
+            response = self._client.chat.completions.create(
+                model=self._model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except Exception as exc:  # pragma: no cover - network failure path
+            raise OpenAIClientError("Nie udało się wywołać OpenAI API.") from exc
+        choices = getattr(response, "choices", None)
+        if not choices:
+            raise OpenAIClientError("OpenAI nie zwróciło żadnych wyników.")
+        message = choices[0].message
+        content = getattr(message, "content", None)
+        if not content:
+            raise OpenAIClientError("Odpowiedź OpenAI nie zawiera treści.")
+        return str(content).strip()
+
+    def _complete_json(self, messages: list[dict[str, str]], *, max_tokens: int = 512) -> Any:
+        content = self._complete(messages, max_tokens=max_tokens)
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise OpenAIClientError("Nie udało się zinterpretować odpowiedzi jako JSON.") from exc
+
+
+@lru_cache(maxsize=1)
+def get_openai_client() -> OpenAIClient:
+    """Return a cached :class:`OpenAIClient` instance."""
+
+    return OpenAIClient()
+

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -19,6 +19,7 @@ from ..models.documents import (
 )
 from ..repositories import DocumentRepository
 from . import exporter, inference, ingestion, indexing, sanitizer
+from .openai_client import OpenAIClientError
 
 
 @dataclass(slots=True)
@@ -111,12 +112,25 @@ class DocumentPipeline:
             )
             await asyncio.to_thread(self._indexer.index, document_id, sanitized_sections)
 
-            metadata.summary = inference.build_summary(sanitized.text)
-            metadata.obligations = inference.extract_obligations(sanitized.text)
-            metadata.penalties = inference.extract_penalties(sanitized.text)
-            metadata.deadlines = inference.extract_deadlines(sanitized.text)
-            metadata.risks = inference.extract_risks(sanitized.text)
-            metadata.simplified_sections = inference.simplify_sections(sanitized_sections)
+            use_cloud = self._settings.enable_cloud_llm
+            try:
+                metadata.summary = inference.build_summary(sanitized.text, use_cloud=use_cloud)
+                metadata.obligations = inference.extract_obligations(sanitized.text, use_cloud=use_cloud)
+                metadata.penalties = inference.extract_penalties(sanitized.text, use_cloud=use_cloud)
+                metadata.deadlines = inference.extract_deadlines(sanitized.text, use_cloud=use_cloud)
+                metadata.risks = inference.extract_risks(sanitized.text, use_cloud=use_cloud)
+                metadata.simplified_sections = inference.simplify_sections(
+                    sanitized_sections, use_cloud=use_cloud
+                )
+            except OpenAIClientError:
+                metadata.summary = inference.build_summary(sanitized.text, use_cloud=False)
+                metadata.obligations = inference.extract_obligations(sanitized.text, use_cloud=False)
+                metadata.penalties = inference.extract_penalties(sanitized.text, use_cloud=False)
+                metadata.deadlines = inference.extract_deadlines(sanitized.text, use_cloud=False)
+                metadata.risks = inference.extract_risks(sanitized.text, use_cloud=False)
+                metadata.simplified_sections = inference.simplify_sections(
+                    sanitized_sections, use_cloud=False
+                )
             metadata.definitions = inference.extract_definitions(sanitized.text)
             metadata.status = DocumentProcessingStatus.READY
             self.repository.upsert(metadata)
@@ -137,7 +151,11 @@ class DocumentPipeline:
                 "Na podstawie zapisanych obowiązków dokument wskazuje: "
                 f"{obligations}"
             )
-        answer = inference.answer_question(question, retrieved)
+        use_cloud = self._settings.enable_cloud_llm
+        try:
+            answer = inference.answer_question(question, retrieved, use_cloud=use_cloud)
+        except OpenAIClientError:
+            answer = inference.answer_question(question, retrieved, use_cloud=False)
         if answer.sources:
             sources = ", ".join(answer.sources)
             return f"{answer.content} Źródła: {sources}."

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.30.1
 pydantic>=2.7,<3.0
 PyPDF2>=3.0,<4.0
 pydantic-settings>=2.0,<3.0
+openai>=1.0,<2.0

--- a/backend/tests/test_pipeline_llm.py
+++ b/backend/tests/test_pipeline_llm.py
@@ -1,0 +1,225 @@
+"""Tests ensuring the pipeline switches between OpenAI and heuristic modes."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+pytest.importorskip("pydantic")
+
+from app.models.documents import DocumentMetadata, DocumentProcessingStatus
+from app.services.ingestion import DocumentSection, ExtractedDocument
+from app.services.indexing import RetrievedChunk
+from app.services.pipeline import DocumentPipeline
+from app.services.sanitizer import SanitizationResult
+
+
+class InMemoryRepository:
+    def __init__(self) -> None:
+        self._store: dict = {}
+
+    def upsert(self, document: DocumentMetadata) -> None:
+        self._store[document.document_id] = document
+
+    def get(self, document_id):
+        return self._store[document_id]
+
+    def list(self) -> Iterable[DocumentMetadata]:
+        return list(self._store.values())
+
+
+class DummyIndexer:
+    def __init__(self) -> None:
+        self._documents: dict = {}
+        self.retrieve_calls: list[tuple] = []
+
+    def index(self, document_id, sections: Iterable[DocumentSection]) -> None:
+        sections = list(sections)
+        self._documents[document_id] = sections
+
+    def retrieve(self, document_id, query: str, top_k: int):
+        self.retrieve_calls.append((document_id, query, top_k))
+        sections = self._documents.get(document_id, [])
+        if not sections:
+            return []
+        first = sections[0]
+        return [RetrievedChunk(identifier=first.identifier, score=1.0, text=first.text)]
+
+
+@dataclass
+class DummySettings:
+    data_dir: Path
+    enable_cloud_llm: bool
+    llm_provider: str = "openai"
+    openai_model: str = "gpt-test"
+
+
+class DummyOpenAIClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+
+    def summarise(self, text: str) -> str:
+        self.calls.append(("summarise", text))
+        return "Streszczenie z chmury"
+
+    def extract_items(self, text: str, category: str) -> list[str]:
+        self.calls.append(("extract_items", category))
+        return [f"AI {category}"]
+
+    def simplify_sections(self, sections: Iterable[DocumentSection]) -> list[dict[str, str]]:
+        sections = list(sections)
+        self.calls.append(("simplify_sections", [section.identifier for section in sections]))
+        return [
+            {
+                "identifier": section.identifier,
+                "plain_language": f"Uproszczenie {section.identifier}",
+                "source_excerpt": "fragment",
+            }
+            for section in sections
+        ]
+
+    def answer_question(self, question: str, retrieved_chunks: Iterable[RetrievedChunk]):
+        self.calls.append(("answer_question", question))
+        return {
+            "answer": "Odpowiedź z chmury",
+            "sources": [chunk.identifier for chunk in retrieved_chunks],
+        }
+
+
+def _setup_documents(tmp_path: Path) -> tuple[InMemoryRepository, DummyIndexer, DocumentMetadata]:
+    repository = InMemoryRepository()
+    indexer = DummyIndexer()
+    metadata = DocumentMetadata(title="Test")
+    metadata.source_path = tmp_path / "source.txt"
+    repository.upsert(metadata)
+    return repository, indexer, metadata
+
+
+def test_run_pipeline_uses_openai_when_enabled(tmp_path):
+    repository, indexer, metadata = _setup_documents(tmp_path)
+    settings = DummySettings(data_dir=tmp_path, enable_cloud_llm=True)
+    extracted_original = ExtractedDocument(
+        text="Treść oryginalna",
+        sections=[DocumentSection(identifier="section-1", text="Treść oryginalna")],
+    )
+    sanitized_text = "To jest przykładowy tekst."
+    extracted_sanitized = ExtractedDocument(
+        text=sanitized_text,
+        sections=[DocumentSection(identifier="section-1", text=sanitized_text)],
+    )
+    sanitization_result = SanitizationResult(text=sanitized_text, entities={}, secrets={})
+    client = DummyOpenAIClient()
+
+    def fake_extract(path):
+        if path == metadata.source_path:
+            return extracted_original
+        return extracted_sanitized
+
+    with patch("app.services.pipeline.get_settings", return_value=settings), patch(
+        "app.services.inference.get_openai_client", return_value=client
+    ), patch("app.services.ingestion.extract_document", side_effect=fake_extract), patch(
+        "app.services.sanitizer.sanitize_text", return_value=sanitization_result
+    ):
+        pipeline = DocumentPipeline(repository=repository, indexer=indexer)
+        asyncio.run(pipeline._run_pipeline(metadata.document_id))
+
+    processed = repository.get(metadata.document_id)
+    assert processed.status is DocumentProcessingStatus.READY
+    assert processed.summary == "Streszczenie z chmury"
+    assert processed.obligations == ["AI obowiązki"]
+    assert processed.penalties == ["AI kary lub sankcje"]
+    assert processed.deadlines == ["AI terminy lub daty graniczne"]
+    assert processed.risks == ["AI ryzyka dla stron umowy"]
+    assert all(section.plain_language.startswith("Uproszczenie") for section in processed.simplified_sections)
+    called_operations = [name for name, _ in client.calls]
+    assert "summarise" in called_operations
+    assert "simplify_sections" in called_operations
+
+
+def test_run_pipeline_uses_heuristics_when_cloud_disabled(tmp_path):
+    repository, indexer, metadata = _setup_documents(tmp_path)
+    settings = DummySettings(data_dir=tmp_path, enable_cloud_llm=False)
+    text_body = "Należy zapłacić karę do 7 dni."
+    extracted = ExtractedDocument(
+        text=text_body,
+        sections=[DocumentSection(identifier="section-1", text=text_body)],
+    )
+    sanitization_result = SanitizationResult(text=text_body, entities={}, secrets={})
+
+    def fake_extract(path):
+        return extracted
+
+    with patch("app.services.pipeline.get_settings", return_value=settings), patch(
+        "app.services.inference.get_openai_client", side_effect=AssertionError("Should not call OpenAI")
+    ), patch("app.services.ingestion.extract_document", side_effect=fake_extract), patch(
+        "app.services.sanitizer.sanitize_text", return_value=sanitization_result
+    ):
+        pipeline = DocumentPipeline(repository=repository, indexer=indexer)
+        asyncio.run(pipeline._run_pipeline(metadata.document_id))
+
+    processed = repository.get(metadata.document_id)
+    assert processed.summary == "Należy zapłacić karę do 7 dni."
+    assert processed.obligations == ["Należy zapłacić karę do 7 dni."]
+    assert processed.penalties == ["Należy zapłacić karę do 7 dni."]
+    assert processed.deadlines == ["Należy zapłacić karę do 7 dni."]
+
+
+def test_answer_question_uses_openai_when_enabled(tmp_path):
+    repository, indexer, metadata = _setup_documents(tmp_path)
+    settings = DummySettings(data_dir=tmp_path, enable_cloud_llm=True)
+    base_text = "To jest sekcja testowa."
+    extracted = ExtractedDocument(
+        text=base_text,
+        sections=[DocumentSection(identifier="section-1", text=base_text)],
+    )
+    sanitization_result = SanitizationResult(text=base_text, entities={}, secrets={})
+    client = DummyOpenAIClient()
+
+    def fake_extract(path):
+        return extracted
+
+    with patch("app.services.pipeline.get_settings", return_value=settings), patch(
+        "app.services.inference.get_openai_client", return_value=client
+    ), patch("app.services.ingestion.extract_document", side_effect=fake_extract), patch(
+        "app.services.sanitizer.sanitize_text", return_value=sanitization_result
+    ):
+        pipeline = DocumentPipeline(repository=repository, indexer=indexer)
+        asyncio.run(pipeline._run_pipeline(metadata.document_id))
+        answer = asyncio.run(pipeline.answer_question(metadata.document_id, "Jakie są obowiązki?"))
+
+    assert answer.startswith("Odpowiedź z chmury")
+    assert any(call[0] == "answer_question" for call in client.calls)
+
+
+def test_answer_question_uses_heuristics_when_cloud_disabled(tmp_path):
+    repository, indexer, metadata = _setup_documents(tmp_path)
+    settings = DummySettings(data_dir=tmp_path, enable_cloud_llm=False)
+    base_text = "To jest sekcja testowa z obowiązkiem."
+    extracted = ExtractedDocument(
+        text=base_text,
+        sections=[DocumentSection(identifier="section-1", text=base_text)],
+    )
+    sanitization_result = SanitizationResult(text=base_text, entities={}, secrets={})
+
+    def fake_extract(path):
+        return extracted
+
+    with patch("app.services.pipeline.get_settings", return_value=settings), patch(
+        "app.services.inference.get_openai_client", side_effect=AssertionError("Should not call OpenAI")
+    ), patch("app.services.ingestion.extract_document", side_effect=fake_extract), patch(
+        "app.services.sanitizer.sanitize_text", return_value=sanitization_result
+    ):
+        pipeline = DocumentPipeline(repository=repository, indexer=indexer)
+        asyncio.run(pipeline._run_pipeline(metadata.document_id))
+        answer = asyncio.run(pipeline.answer_question(metadata.document_id, "Jakie są obowiązki?"))
+
+    assert "heurystycznie" in answer


### PR DESCRIPTION
## Summary
- add the official OpenAI client as a dependency together with a thin wrapper tailored for the document pipeline
- extend the inference utilities to use the cloud LLM when enabled while keeping deterministic heuristics as a fallback
- update the document pipeline to switch between OpenAI and local processing and cover both paths with targeted unit tests

## Testing
- pytest backend/tests/test_pipeline_llm.py *(skipped: missing pydantic dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e05265d7188326ae5433f54bf44e3a