### PR TITLE
Add detailed logging for document processing workflow

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1,5 +1,6 @@
 """Document lifecycle endpoints."""
 from collections.abc import Iterable
+import logging
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, UploadFile
@@ -19,6 +20,8 @@ from ...services.pipeline import (
     DocumentPipeline,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 pipeline = DocumentPipeline()
@@ -27,7 +30,9 @@ pipeline = DocumentPipeline()
 @router.post("/", summary="Upload a document for processing", response_model=DocumentCreateResponse)
 async def upload_document(file: UploadFile) -> DocumentCreateResponse:
     """Persist an uploaded file and trigger asynchronous processing."""
+    logger.info("Received upload request for %s", file.filename)
     document = await pipeline.ingest(file)
+    logger.info("Document %s accepted for processing", document.document_id)
     return DocumentCreateResponse(document_id=document.document_id, status=document.status)
 
 
@@ -38,6 +43,7 @@ async def upload_document(file: UploadFile) -> DocumentCreateResponse:
 )
 async def list_documents() -> Iterable[DocumentMetadataPublic]:
     """Return metadata for all processed documents in the local store."""
+    logger.debug("Listing processed documents")
     return [document.to_public() for document in pipeline.iter_documents()]
 
 
@@ -51,17 +57,22 @@ async def get_document(document_id: UUID) -> DocumentMetadataPublic:
     try:
         document = pipeline.get_document(document_id)
     except DocumentNotFoundError as exc:
+        logger.warning("Requested metadata for missing document %s", document_id)
         raise HTTPException(status_code=404, detail="Document not found") from exc
+    logger.debug("Returning metadata for %s", document_id)
     return document.to_public()
 
 
 @router.get("/{document_id}/qa", summary="Ask a question about a document")
 async def ask_question(document_id: UUID, question: str) -> dict[str, str]:
     """Provide a lightweight placeholder for document Q&A functionality."""
+    logger.info("Received Q&A request for %s", document_id)
     try:
         answer = await pipeline.answer_question(document_id=document_id, question=question)
     except DocumentNotFoundError as exc:
+        logger.warning("Q&A requested for missing document %s", document_id)
         raise HTTPException(status_code=404, detail="Document not found") from exc
+    logger.debug("Returning Q&A response for %s", document_id)
     return {"answer": answer}
 
 
@@ -79,10 +90,15 @@ async def export_document(
             document_id=document_id, format=format, restore_pii=restore_pii
         )
     except DocumentNotFoundError as exc:
+        logger.warning("Export requested for missing document %s", document_id)
         raise HTTPException(status_code=404, detail="Document not found") from exc
     except DocumentNotReadyError as exc:
+        logger.info("Export requested for processing document %s", document_id)
         raise HTTPException(status_code=409, detail="Document is still processing") from exc
     except ValueError as exc:
+        logger.warning(
+            "Export request for %s failed due to invalid input: %s", document_id, exc
+        )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     headers = {
         "Content-Disposition": f'attachment; filename="{artefact.filename}"'
@@ -103,9 +119,12 @@ async def get_simplified_document(document_id: UUID) -> DocumentSimplifiedRespon
     try:
         sections = pipeline.get_simplified_sections(document_id)
     except DocumentNotFoundError as exc:
+        logger.warning("Simplified view requested for missing document %s", document_id)
         raise HTTPException(status_code=404, detail="Document not found") from exc
     except DocumentNotReadyError as exc:
+        logger.info("Simplified view requested for processing document %s", document_id)
         raise HTTPException(status_code=409, detail="Document is still processing") from exc
+    logger.debug("Returning simplified sections for %s", document_id)
     return DocumentSimplifiedResponse(document_id=document_id, sections=sections)
 
 
@@ -120,9 +139,12 @@ async def get_definitions(document_id: UUID) -> DocumentDefinitionsResponse:
     try:
         metadata = pipeline.get_document(document_id)
     except DocumentNotFoundError as exc:
+        logger.warning("Definitions requested for missing document %s", document_id)
         raise HTTPException(status_code=404, detail="Document not found") from exc
     if metadata.status != DocumentProcessingStatus.READY:
+        logger.info("Definitions requested for processing document %s", document_id)
         raise HTTPException(status_code=409, detail="Document is still processing")
+    logger.debug("Returning definitions for %s", document_id)
     return DocumentDefinitionsResponse(document_id=document_id, definitions=metadata.definitions)
 
 
@@ -137,7 +159,10 @@ async def get_insights(document_id: UUID) -> DocumentInsightsResponse:
     try:
         insights = pipeline.get_document_insights(document_id)
     except DocumentNotFoundError as exc:
+        logger.warning("Insights requested for missing document %s", document_id)
         raise HTTPException(status_code=404, detail="Document not found") from exc
     except DocumentNotReadyError as exc:
+        logger.info("Insights requested for processing document %s", document_id)
         raise HTTPException(status_code=409, detail="Document is still processing") from exc
+    logger.debug("Returning insights for %s", document_id)
     return DocumentInsightsResponse(document_id=document_id, **insights)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
 
 
 def _discover_project_root(start_path: Path | None = None) -> Path:

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from functools import lru_cache
 from typing import Any, Iterable
 
@@ -10,6 +11,9 @@ from openai import OpenAI
 from ..core.config import get_settings
 from .indexing import RetrievedChunk
 from .ingestion import DocumentSection
+
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAIClientError(RuntimeError):
@@ -25,6 +29,7 @@ class OpenAIClient:
         self._model = settings.openai_model
 
     def summarise(self, text: str) -> str:
+        logger.debug("Requesting OpenAI summary (%d chars)", len(text))
         messages = [
             {
                 "role": "system",
@@ -41,9 +46,12 @@ class OpenAIClient:
                 ),
             },
         ]
-        return self._complete(messages, max_tokens=300)
+        summary = self._complete(messages, max_tokens=300)
+        logger.debug("Received OpenAI summary response (%d chars)", len(summary))
+        return summary
 
     def extract_items(self, text: str, category: str) -> list[str]:
+        logger.debug("Requesting OpenAI extraction for '%s' (%d chars)", category, len(text))
         messages = [
             {
                 "role": "system",
@@ -62,6 +70,11 @@ class OpenAIClient:
             },
         ]
         data = self._complete_json(messages, max_tokens=400)
+        logger.debug(
+            "Received OpenAI extraction response for '%s': %s",
+            category,
+            data,
+        )
         if not isinstance(data, list):
             raise OpenAIClientError("Nieprawidłowy format odpowiedzi dla listy elementów.")
         cleaned: list[str] = []
@@ -98,7 +111,14 @@ class OpenAIClient:
                 ),
             },
         ]
+        logger.debug("Requesting OpenAI simplification for %d sections", len(payload))
         data = self._complete_json(messages, max_tokens=1200)
+        if isinstance(data, list):
+            logger.debug("Received OpenAI simplification response with %d items", len(data))
+        else:
+            logger.debug(
+                "Received OpenAI simplification response of type %s", type(data).__name__
+            )
         if not isinstance(data, list):
             raise OpenAIClientError("Oczekiwano tablicy z uproszczeniami sekcji.")
         results: list[dict[str, str]] = []
@@ -150,7 +170,13 @@ class OpenAIClient:
                 ),
             },
         ]
+        logger.debug(
+            "Requesting OpenAI answer (question length: %d, context items: %d)",
+            len(question),
+            len(context),
+        )
         data = self._complete_json(messages, max_tokens=600)
+        logger.debug("Received OpenAI answer response: %s", data)
         if not isinstance(data, dict):
             raise OpenAIClientError("Niepoprawny format odpowiedzi dla Q&A.")
         answer = str(data.get("answer", "")).strip()
@@ -165,6 +191,12 @@ class OpenAIClient:
 
     def _complete(self, messages: list[dict[str, str]], *, max_tokens: int = 512, temperature: float = 0.2) -> str:
         try:
+            logger.debug(
+                "Calling OpenAI chat completion (model=%s, max_tokens=%d, temperature=%.2f)",
+                self._model,
+                max_tokens,
+                temperature,
+            )
             response = self._client.chat.completions.create(
                 model=self._model,
                 messages=messages,
@@ -172,21 +204,26 @@ class OpenAIClient:
                 max_tokens=max_tokens,
             )
         except Exception as exc:  # pragma: no cover - network failure path
+            logger.exception("OpenAI chat completion failed")
             raise OpenAIClientError("Nie udało się wywołać OpenAI API.") from exc
         choices = getattr(response, "choices", None)
         if not choices:
+            logger.error("OpenAI response did not include choices")
             raise OpenAIClientError("OpenAI nie zwróciło żadnych wyników.")
         message = choices[0].message
         content = getattr(message, "content", None)
         if not content:
+            logger.error("OpenAI response message missing content")
             raise OpenAIClientError("Odpowiedź OpenAI nie zawiera treści.")
         return str(content).strip()
 
     def _complete_json(self, messages: list[dict[str, str]], *, max_tokens: int = 512) -> Any:
         content = self._complete(messages, max_tokens=max_tokens)
         try:
-            return json.loads(content)
+            parsed = json.loads(content)
+            return parsed
         except json.JSONDecodeError as exc:
+            logger.error("Failed to decode OpenAI JSON response: %s", content, exc_info=True)
             raise OpenAIClientError("Nie udało się zinterpretować odpowiedzi jako JSON.") from exc
 
 

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 import json
 import os
@@ -20,6 +21,9 @@ from ..models.documents import (
 from ..repositories import DocumentRepository
 from . import exporter, inference, ingestion, indexing, sanitizer
 from .openai_client import OpenAIClientError
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -66,6 +70,9 @@ class DocumentPipeline:
         metadata = DocumentMetadata(title=file.filename or "unknown")
         await self._persist_upload(file, metadata)
         self.repository.upsert(metadata)
+        logger.info(
+            "Queued document %s (%s) for processing", metadata.document_id, metadata.title
+        )
         loop = asyncio.get_running_loop()
 
         def _runner() -> None:
@@ -79,17 +86,31 @@ class DocumentPipeline:
             metadata = self._get(document_id)
             metadata.status = DocumentProcessingStatus.PROCESSING
             self.repository.upsert(metadata)
+            logger.info("Starting processing workflow for %s", document_id)
 
             if metadata.source_path is None:
                 raise ValueError("Document source path missing")
 
+            logger.debug("Extracting text from %s", metadata.source_path)
             extracted = await asyncio.to_thread(ingestion.extract_document, metadata.source_path)
+            logger.debug(
+                "Extracted %d sections (%d chars) for %s",
+                len(extracted.sections),
+                len(extracted.text),
+                document_id,
+            )
             sanitized = await asyncio.to_thread(sanitizer.sanitize_text, extracted.text)
+            logger.debug(
+                "Sanitised text for %s with %d placeholders",
+                document_id,
+                len(sanitized.entities),
+            )
 
             sanitized_dir = self._settings.data_dir / str(document_id) / "sanitized"
             sanitized_dir.mkdir(parents=True, exist_ok=True)
             sanitized_path = sanitized_dir / "document.txt"
             sanitized_path.write_text(sanitized.text, encoding="utf-8")
+            logger.debug("Persisted sanitised document for %s at %s", document_id, sanitized_path)
 
             secure_dir = self._settings.data_dir / str(document_id) / "secure"
             secure_dir.mkdir(parents=True, exist_ok=True)
@@ -110,10 +131,17 @@ class DocumentPipeline:
             sanitized_sections = await asyncio.to_thread(
                 lambda: ingestion.extract_document(sanitized_path).sections
             )
+            logger.debug("Prepared %d sanitised sections for %s", len(sanitized_sections), document_id)
             await asyncio.to_thread(self._indexer.index, document_id, sanitized_sections)
+            logger.info("Indexed sanitised sections for %s", document_id)
 
             use_cloud = self._settings.enable_cloud_llm
             try:
+                logger.info(
+                    "Running inference for %s using %s models",
+                    document_id,
+                    "OpenAI" if use_cloud else "local",
+                )
                 metadata.summary = inference.build_summary(sanitized.text, use_cloud=use_cloud)
                 metadata.obligations = inference.extract_obligations(sanitized.text, use_cloud=use_cloud)
                 metadata.penalties = inference.extract_penalties(sanitized.text, use_cloud=use_cloud)
@@ -123,6 +151,11 @@ class DocumentPipeline:
                     sanitized_sections, use_cloud=use_cloud
                 )
             except OpenAIClientError:
+                logger.warning(
+                    "Falling back to local inference for %s due to OpenAI failure",
+                    document_id,
+                    exc_info=True,
+                )
                 metadata.summary = inference.build_summary(sanitized.text, use_cloud=False)
                 metadata.obligations = inference.extract_obligations(sanitized.text, use_cloud=False)
                 metadata.penalties = inference.extract_penalties(sanitized.text, use_cloud=False)
@@ -134,31 +167,53 @@ class DocumentPipeline:
             metadata.definitions = inference.extract_definitions(sanitized.text)
             metadata.status = DocumentProcessingStatus.READY
             self.repository.upsert(metadata)
+            logger.info("Completed processing workflow for %s", document_id)
         except Exception as exc:  # pragma: no cover - defensive path
             metadata = self._get(document_id)
             metadata.status = DocumentProcessingStatus.FAILED
             metadata.extra["error"] = str(exc)
             self.repository.upsert(metadata)
+            logger.exception("Processing workflow for %s failed: %s", document_id, exc)
 
     async def answer_question(self, document_id: UUID, question: str) -> str:
         metadata = self._get(document_id)
         if metadata.status != DocumentProcessingStatus.READY:
+            logger.info(
+                "Document %s not ready for Q&A (status: %s)",
+                document_id,
+                metadata.status,
+            )
             return "Dokument jest nadal przetwarzany. Spróbuj ponownie później."
+        logger.debug("Retrieving context for question on %s", document_id)
         retrieved = await asyncio.to_thread(self._indexer.retrieve, document_id, question, 3)
         if not retrieved and metadata.obligations:
             obligations = "; ".join(metadata.obligations[:3])
+            logger.info(
+                "Using obligation fallback to answer question for %s", document_id
+            )
             return (
                 "Na podstawie zapisanych obowiązków dokument wskazuje: "
                 f"{obligations}"
             )
         use_cloud = self._settings.enable_cloud_llm
         try:
+            logger.debug(
+                "Generating answer for document %s using %s models",
+                document_id,
+                "OpenAI" if use_cloud else "local",
+            )
             answer = inference.answer_question(question, retrieved, use_cloud=use_cloud)
         except OpenAIClientError:
+            logger.warning(
+                "Falling back to local Q&A for %s due to OpenAI failure",
+                document_id,
+                exc_info=True,
+            )
             answer = inference.answer_question(question, retrieved, use_cloud=False)
         if answer.sources:
             sources = ", ".join(answer.sources)
             return f"{answer.content} Źródła: {sources}."
+        logger.debug("Generated answer for %s without explicit sources", document_id)
         return answer.content
 
     async def export_document(
@@ -171,11 +226,15 @@ class DocumentPipeline:
 
         metadata = self._get(document_id)
         if metadata.status != DocumentProcessingStatus.READY:
+            logger.info("Export requested for %s but document not ready", document_id)
             raise DocumentNotReadyError(document_id)
 
         normalised = format.lower()
         supported = {"markdown", "pdf", "docx"}
         if normalised not in supported:
+            logger.warning(
+                "Unsupported export format '%s' requested for %s", format, document_id
+            )
             raise ValueError(f"Unsupported export format: {format}")
 
         if restore_pii and (not metadata.pii_secret_path or not metadata.pii_secret_path.exists()):
@@ -188,6 +247,7 @@ class DocumentPipeline:
                 media_type="text/markdown",
                 content=payload.encode("utf-8"),
             )
+        logger.info("Generating %s export for %s", normalised, document_id)
         if normalised == "pdf":
             payload = await asyncio.to_thread(exporter.generate_pdf, metadata, restore_pii=restore_pii)
             return ExportArtefact(
@@ -236,6 +296,12 @@ class DocumentPipeline:
         destination.write_bytes(content)
         metadata.source_path = destination
         await file.close()
+        logger.debug(
+            "Persisted uploaded file for %s at %s (%d bytes)",
+            metadata.document_id,
+            destination,
+            len(content),
+        )
 
     def _rehydrate_index(self) -> None:
         for document in self.repository.list():
@@ -243,6 +309,7 @@ class DocumentPipeline:
                 continue
             extracted = ingestion.extract_document(document.sanitized_path)
             self._indexer.index(document.document_id, extracted.sections)
+            logger.debug("Rehydrated index for %s", document.document_id)
 
     def _get(self, document_id: UUID) -> DocumentMetadata:
         try:


### PR DESCRIPTION
## Summary
- add logging across document API endpoints to trace user interactions
- extend pipeline and OpenAI client with detailed processing diagnostics
- configure the FastAPI app to emit INFO-level logs by default

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0604590d08326ac78cc1d0523db71