### PR TITLE
Handle OpenAI authentication errors safely

### DIFF
--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -6,7 +6,7 @@ import logging
 from functools import lru_cache
 from typing import Any, Iterable
 
-from openai import OpenAI
+from openai import AuthenticationError, OpenAI
 
 from ..core.config import get_settings
 from .indexing import RetrievedChunk
@@ -203,6 +203,15 @@ class OpenAIClient:
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
+        except AuthenticationError as exc:  # pragma: no cover - network failure path
+            message = str(exc)
+            if ":" in message:
+                prefix, _ = message.split(":", 1)
+                message = f"{prefix}: [REDACTED]"
+            else:
+                message = "OpenAI authentication failed: [REDACTED]"
+            logger.warning(message)
+            raise OpenAIClientError("Nie udało się uwierzytelnić w OpenAI API.") from exc
         except Exception as exc:  # pragma: no cover - network failure path
             logger.exception("OpenAI chat completion failed")
             raise OpenAIClientError("Nie udało się wywołać OpenAI API.") from exc

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,53 @@ from __future__ import annotations
 """Pytest configuration and compatibility shims for the test suite."""
 
 import inspect
+import sys
+import types
 import typing
+
+
+def _ensure_pydantic_stubs() -> None:
+    if "pydantic" not in sys.modules:  # pragma: no cover - executed in CI without dependency
+        module = types.ModuleType("pydantic")
+
+        def Field(default=None, **kwargs):  # pragma: no cover - simple stub
+            return default
+
+        module.Field = Field
+        sys.modules["pydantic"] = module
+
+    if "pydantic_settings" not in sys.modules:  # pragma: no cover - executed in CI without dependency
+        module = types.ModuleType("pydantic_settings")
+
+        class BaseSettings:  # pragma: no cover - simple stub
+            def __init__(self, **kwargs) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+        module.BaseSettings = BaseSettings
+        sys.modules["pydantic_settings"] = module
+
+
+def _ensure_openai_stub() -> None:
+    try:
+        import openai  # noqa: F401  # pragma: no cover - optional dependency
+    except ModuleNotFoundError:  # pragma: no cover - executed in CI without openai
+        module = types.ModuleType("openai")
+
+        class AuthenticationError(Exception):
+            """Fallback authentication error used in tests."""
+
+        class _StubCompletions:  # pragma: no cover - simple stub
+            def create(self, *args, **kwargs):
+                raise RuntimeError("OpenAI API is not available in the test environment.")
+
+        class OpenAI:  # pragma: no cover - simple stub
+            def __init__(self, *args, **kwargs) -> None:
+                self.chat = types.SimpleNamespace(completions=_StubCompletions())
+
+        module.AuthenticationError = AuthenticationError
+        module.OpenAI = OpenAI
+        sys.modules["openai"] = module
 
 
 def _ensure_forward_ref_compatibility() -> None:
@@ -31,4 +77,6 @@ def _ensure_forward_ref_compatibility() -> None:
     setattr(forward_ref, "_evaluate", _patched)
 
 
+_ensure_pydantic_stubs()
 _ensure_forward_ref_compatibility()
+_ensure_openai_stub()

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -1,0 +1,43 @@
+"""Tests for the OpenAI client helper."""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openai import AuthenticationError
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.services.openai_client import OpenAIClient, OpenAIClientError
+
+
+class _FailingCompletions:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def create(self, **_: object):  # pragma: no cover - simple helper
+        raise self._exc
+
+
+class _FailingClient:
+    def __init__(self, exc: Exception) -> None:
+        self.chat = SimpleNamespace(completions=_FailingCompletions(exc))
+
+
+def test_complete_masks_authentication_error(caplog):
+    message = "Incorrect API key provided: sk-test123"
+    client = OpenAIClient(client=_FailingClient(AuthenticationError(message)))
+
+    with caplog.at_level(logging.WARNING), pytest.raises(OpenAIClientError):
+        client._complete([{"role": "user", "content": "Hello"}])
+
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+    assert all("sk-test123" not in record.message for record in caplog.records)
+    assert any("[REDACTED]" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- mask OpenAI AuthenticationError messages before logging
- add lightweight stubs for optional dependencies used by the OpenAI client tests
- cover the new behaviour with a unit test that ensures sensitive tokens are redacted

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e066039668832684acc200f10ee136