### PR TITLE
Ensure OpenAI client requires explicit API key configuration

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,24 +1,58 @@
 """Application-wide configuration and settings."""
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import Field
-from pydantic_settings import BaseSettings
+try:  # pragma: no cover - compatibility with Pydantic v1
+    from pydantic import AliasChoices, Field
+except ImportError:  # pragma: no cover - fallback for older versions
+    AliasChoices = None  # type: ignore[assignment]
+    from pydantic import Field
+try:  # pragma: no cover - compatibility with pydantic-settings v1
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+except ImportError:  # pragma: no cover - fallback when SettingsConfigDict is unavailable
+    from pydantic_settings import BaseSettings  # type: ignore[no-redef]
+
+    SettingsConfigDict = None  # type: ignore[assignment]
 
 
 class Settings(BaseSettings):
     """Define high-level configuration knobs for the monolith."""
 
+    if SettingsConfigDict is not None:
+        model_config = SettingsConfigDict(
+            env_file=".env",
+            env_file_encoding="utf-8",
+            env_prefix="PROSTE_PRAWO_",
+            case_sensitive=False,
+        )
+
     data_dir: Path = Field(default=Path("data"), description="Root directory for stored artefacts.")
     enable_cloud_llm: bool = Field(default=True, description="Allow outbound LLM requests after sanitisation.")
     llm_provider: str = Field(default="openai", description="Default LLM provider identifier.")
     openai_model: str = Field(default="gpt-4o-mini", description="Baseline model for simplification tasks.")
+    openai_api_key: str | None = Field(
+        default=None,
+        description="API key used for authenticating OpenAI requests.",
+        **(
+            {"validation_alias": AliasChoices("OPENAI_API_KEY", "PROSTE_PRAWO_OPENAI_API_KEY")}
+            if AliasChoices is not None
+            else {}
+        ),
+    )
 
-    class Config:
+    class Config:  # pragma: no cover - maintained for Pydantic v1
         env_prefix = "PROSTE_PRAWO_"
         case_sensitive = False
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        fields = {
+            "openai_api_key": {
+                "env": ["PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"],
+            }
+        }
 
 
 @lru_cache(maxsize=1)
@@ -26,5 +60,26 @@ def get_settings() -> Settings:
     """Return the cached application settings instance."""
 
     settings = Settings()
+    if not settings.openai_api_key:
+        for env_var in ("PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"):
+            value = os.getenv(env_var)
+            if not value:
+                env_path = Path(".env")
+                if env_path.exists():
+                    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+                        line = raw_line.strip()
+                        if not line or line.startswith("#") or "=" not in line:
+                            continue
+                        key, raw_value = line.split("=", 1)
+                        if key.strip() != env_var:
+                            continue
+                        candidate = raw_value.strip().strip('"').strip("'")
+                        if candidate:
+                            value = candidate
+                            break
+                if not value:
+                    continue
+            settings.openai_api_key = value
+            break
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     return settings

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -25,7 +25,15 @@ class OpenAIClient:
 
     def __init__(self, client: OpenAI | None = None) -> None:
         settings = get_settings()
-        self._client = client or OpenAI()
+        if client is None:
+            api_key = settings.openai_api_key
+            if not api_key:
+                raise RuntimeError(
+                    "OpenAI API key is missing. Set OPENAI_API_KEY or PROSTE_PRAWO_OPENAI_API_KEY."
+                )
+            self._client = OpenAI(api_key=api_key)
+        else:
+            self._client = client
         self._model = settings.openai_model
 
     def summarise(self, text: str) -> str:

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -15,6 +15,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from app.core.config import get_settings
 from app.services.openai_client import OpenAIClient, OpenAIClientError
 
 
@@ -41,3 +42,43 @@ def test_complete_masks_authentication_error(caplog):
     assert any(record.levelno == logging.WARNING for record in caplog.records)
     assert all("sk-test123" not in record.message for record in caplog.records)
     assert any("[REDACTED]" in record.message for record in caplog.records)
+
+
+def test_client_uses_api_key_from_env(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENAI_API_KEY=from_env\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("PROSTE_PRAWO_OPENAI_API_KEY", raising=False)
+    get_settings.cache_clear()
+    captured: dict[str, object] = {}
+
+    class _DummyOpenAI:
+        def __init__(self, *args, **kwargs) -> None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda *a, **k: None)
+            )
+
+    monkeypatch.setattr("app.services.openai_client.OpenAI", _DummyOpenAI)
+    try:
+        OpenAIClient()
+    finally:
+        get_settings.cache_clear()
+
+    assert captured.get("kwargs", {}).get("api_key") == "from_env"
+
+
+def test_client_requires_api_key(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("PROSTE_PRAWO_OPENAI_API_KEY", raising=False)
+    get_settings.cache_clear()
+
+    try:
+        with pytest.raises(RuntimeError, match="OpenAI API key is missing"):
+            OpenAIClient()
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- load the backend settings from the project .env file and expose an OpenAI API key that understands both prefixed and unprefixed environment variables
- inject the resolved key when constructing the OpenAI client and raise a clear error when it is missing
- extend the OpenAI client test coverage to verify .env loading and the failure path without a key

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e067e02fe8832685730cb40c023706