### PR TITLE
Fix SettingsConfigDict compatibility

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,17 @@ class Settings(BaseSettings):
             env_prefix="PROSTE_PRAWO_",
             case_sensitive=False,
         )
+    else:
+        class Config:  # pragma: no cover - maintained for Pydantic v1
+            env_prefix = "PROSTE_PRAWO_"
+            case_sensitive = False
+            env_file = ".env"
+            env_file_encoding = "utf-8"
+            fields = {
+                "openai_api_key": {
+                    "env": ["PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"],
+                }
+            }
 
     data_dir: Path = Field(default=Path("data"), description="Root directory for stored artefacts.")
     enable_cloud_llm: bool = Field(default=True, description="Allow outbound LLM requests after sanitisation.")
@@ -42,17 +53,6 @@ class Settings(BaseSettings):
             else {}
         ),
     )
-
-    class Config:  # pragma: no cover - maintained for Pydantic v1
-        env_prefix = "PROSTE_PRAWO_"
-        case_sensitive = False
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        fields = {
-            "openai_api_key": {
-                "env": ["PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"],
-            }
-        }
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- adjust `Settings` so the legacy `Config` inner class is only defined when `SettingsConfigDict` is unavailable
- preserve the Pydantic v2 configuration path by keeping only the `model_config` assignment when `SettingsConfigDict` exists

## Testing
- python - <<'PY'
import sys
import types

# Minimal stubs to emulate Pydantic v2 behaviour for the smoke test
pydantic = types.ModuleType("pydantic")

class AliasChoices:
    def __init__(self, *choices):
        self.choices = choices

def Field(*, default=None, **kwargs):
    return default

pydantic.AliasChoices = AliasChoices
pydantic.Field = Field
sys.modules["pydantic"] = pydantic

pydantic_settings = types.ModuleType("pydantic_settings")

class BaseSettings:
    def __init__(self, **values):
        for key, value in values.items():
            setattr(self, key, value)

class _SettingsConfigDict(dict):
    pass

pydantic_settings.BaseSettings = BaseSettings
pydantic_settings.SettingsConfigDict = _SettingsConfigDict
sys.modules["pydantic_settings"] = pydantic_settings

from backend.app.core.config import get_settings

settings = get_settings()
print(type(settings).__name__)
print(settings.data_dir)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e06b30474883269aa673ee84c62151