### PR TITLE
Add OpenAI project configuration support

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -37,7 +37,10 @@ class Settings(BaseSettings):
             fields = {
                 "openai_api_key": {
                     "env": ["PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"],
-                }
+                },
+                "openai_project": {
+                    "env": ["PROSTE_PRAWO_OPENAI_PROJECT", "OPENAI_PROJECT"],
+                },
             }
 
     data_dir: Path = Field(default=Path("data"), description="Root directory for stored artefacts.")
@@ -53,6 +56,38 @@ class Settings(BaseSettings):
             else {}
         ),
     )
+    openai_project: str | None = Field(
+        default=None,
+        description="Optional OpenAI project identifier used for requests.",
+        **(
+            {"validation_alias": AliasChoices("OPENAI_PROJECT", "PROSTE_PRAWO_OPENAI_PROJECT")}
+            if AliasChoices is not None
+            else {}
+        ),
+    )
+
+
+def _load_env_with_file_fallback(*env_vars: str) -> str | None:
+    """Return the first available value from environment variables or .env file."""
+
+    env_path = Path(".env")
+    for env_var in env_vars:
+        value = os.getenv(env_var)
+        if not value and env_path.exists():
+            for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, raw_value = line.split("=", 1)
+                if key.strip() != env_var:
+                    continue
+                candidate = raw_value.strip().strip('"').strip("'")
+                if candidate:
+                    value = candidate
+                    break
+        if value:
+            return value
+    return None
 
 
 @lru_cache(maxsize=1)
@@ -61,25 +96,16 @@ def get_settings() -> Settings:
 
     settings = Settings()
     if not settings.openai_api_key:
-        for env_var in ("PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"):
-            value = os.getenv(env_var)
-            if not value:
-                env_path = Path(".env")
-                if env_path.exists():
-                    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
-                        line = raw_line.strip()
-                        if not line or line.startswith("#") or "=" not in line:
-                            continue
-                        key, raw_value = line.split("=", 1)
-                        if key.strip() != env_var:
-                            continue
-                        candidate = raw_value.strip().strip('"').strip("'")
-                        if candidate:
-                            value = candidate
-                            break
-                if not value:
-                    continue
+        value = _load_env_with_file_fallback(
+            "PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"
+        )
+        if value:
             settings.openai_api_key = value
-            break
+    if not settings.openai_project:
+        value = _load_env_with_file_fallback(
+            "PROSTE_PRAWO_OPENAI_PROJECT", "OPENAI_PROJECT"
+        )
+        if value:
+            settings.openai_project = value
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     return settings

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -31,7 +31,11 @@ class OpenAIClient:
                 raise RuntimeError(
                     "OpenAI API key is missing. Set OPENAI_API_KEY or PROSTE_PRAWO_OPENAI_API_KEY."
                 )
-            self._client = OpenAI(api_key=api_key)
+            client_kwargs = {"api_key": api_key}
+            openai_project = settings.openai_project
+            if openai_project:
+                client_kwargs["project"] = openai_project
+            self._client = OpenAI(**client_kwargs)
         else:
             self._client = client
         self._model = settings.openai_model

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -70,6 +70,32 @@ def test_client_uses_api_key_from_env(monkeypatch, tmp_path):
     assert captured.get("kwargs", {}).get("api_key") == "from_env"
 
 
+def test_client_passes_project_when_available(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "from_env")
+    monkeypatch.setenv("OPENAI_PROJECT", "project-123")
+    monkeypatch.delenv("PROSTE_PRAWO_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("PROSTE_PRAWO_OPENAI_PROJECT", raising=False)
+    get_settings.cache_clear()
+    captured: dict[str, object] = {}
+
+    class _DummyOpenAI:
+        def __init__(self, *args, **kwargs) -> None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda *a, **k: None)
+            )
+
+    monkeypatch.setattr("app.services.openai_client.OpenAI", _DummyOpenAI)
+    try:
+        OpenAIClient()
+    finally:
+        get_settings.cache_clear()
+
+    assert captured.get("kwargs", {}).get("api_key") == "from_env"
+    assert captured.get("kwargs", {}).get("project") == "project-123"
+
+
 def test_client_requires_api_key(monkeypatch, tmp_path):
     (tmp_path / ".env").write_text("", encoding="utf-8")
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- add optional OpenAI project setting with environment and .env fallbacks
- update OpenAI client to forward the configured project when creating the SDK client
- add regression test covering project propagation to the OpenAI client stub

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e06e9899dc8326b90f8b1983e922ab