### PR TITLE
Fix OpenAI configuration sourcing and logging

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -67,24 +67,37 @@ class Settings(BaseSettings):
     )
 
 
-def _load_env_with_file_fallback(*env_vars: str) -> str | None:
-    """Return the first available value from environment variables or .env file."""
+def _resolve_env_path() -> Path | None:
+    """Return the most relevant ``.env`` file path if available."""
 
-    env_path = Path(".env")
+    cwd_env = Path.cwd() / ".env"
+    if cwd_env.exists():
+        return cwd_env
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / ".env"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _load_env_with_file_fallback(*env_vars: str) -> str | None:
+    """Return the first available value preferring the ``.env`` file."""
+
+    env_path = _resolve_env_path()
+    file_values: dict[str, str] = {}
+    if env_path is not None:
+        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, raw_value = line.split("=", 1)
+            candidate = raw_value.strip().strip('"').strip("'")
+            if candidate:
+                file_values[key.strip()] = candidate
     for env_var in env_vars:
+        if env_var in file_values:
+            return file_values[env_var]
         value = os.getenv(env_var)
-        if not value and env_path.exists():
-            for raw_line in env_path.read_text(encoding="utf-8").splitlines():
-                line = raw_line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                key, raw_value = line.split("=", 1)
-                if key.strip() != env_var:
-                    continue
-                candidate = raw_value.strip().strip('"').strip("'")
-                if candidate:
-                    value = candidate
-                    break
         if value:
             return value
     return None

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -216,13 +216,7 @@ class OpenAIClient:
                 max_tokens=max_tokens,
             )
         except AuthenticationError as exc:  # pragma: no cover - network failure path
-            message = str(exc)
-            if ":" in message:
-                prefix, _ = message.split(":", 1)
-                message = f"{prefix}: [REDACTED]"
-            else:
-                message = "OpenAI authentication failed: [REDACTED]"
-            logger.warning(message)
+            logger.warning("OpenAI authentication failed: %s", exc)
             raise OpenAIClientError("Nie udało się uwierzytelnić w OpenAI API.") from exc
         except Exception as exc:  # pragma: no cover - network failure path
             logger.exception("OpenAI chat completion failed")

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -32,7 +32,7 @@ class _FailingClient:
         self.chat = SimpleNamespace(completions=_FailingCompletions(exc))
 
 
-def test_complete_masks_authentication_error(caplog):
+def test_complete_logs_full_authentication_error(caplog):
     message = "Incorrect API key provided: sk-test123"
     client = OpenAIClient(client=_FailingClient(AuthenticationError(message)))
 
@@ -40,8 +40,8 @@ def test_complete_masks_authentication_error(caplog):
         client._complete([{"role": "user", "content": "Hello"}])
 
     assert any(record.levelno == logging.WARNING for record in caplog.records)
-    assert all("sk-test123" not in record.message for record in caplog.records)
-    assert any("[REDACTED]" in record.message for record in caplog.records)
+    assert any("sk-test123" in record.message for record in caplog.records)
+    assert all("[REDACTED]" not in record.message for record in caplog.records)
 
 
 def test_client_uses_api_key_from_env(monkeypatch, tmp_path):
@@ -68,6 +68,31 @@ def test_client_uses_api_key_from_env(monkeypatch, tmp_path):
         get_settings.cache_clear()
 
     assert captured.get("kwargs", {}).get("api_key") == "from_env"
+
+
+def test_client_prefers_env_file_over_environment(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENAI_API_KEY=from_file\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "from_env")
+    monkeypatch.delenv("PROSTE_PRAWO_OPENAI_API_KEY", raising=False)
+    get_settings.cache_clear()
+    captured: dict[str, object] = {}
+
+    class _DummyOpenAI:
+        def __init__(self, *args, **kwargs) -> None:
+            captured["kwargs"] = kwargs
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda *a, **k: None)
+            )
+
+    monkeypatch.setattr("app.services.openai_client.OpenAI", _DummyOpenAI)
+    try:
+        OpenAIClient()
+    finally:
+        get_settings.cache_clear()
+
+    assert captured.get("kwargs", {}).get("api_key") == "from_file"
 
 
 def test_client_passes_project_when_available(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure the OpenAI settings loader finds the nearest .env file and prefers its values over environment overrides
- log full authentication failures without redacting the API key to aid local debugging
- extend OpenAI client tests to cover the new logging behaviour and .env precedence

## Testing
- pytest *(fails: missing pydantic dependency required by the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e07064e7f08326895094104e0c4c3b