### PR TITLE
Ensure .env overrides prefixed OpenAI key

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -97,6 +97,7 @@ def _load_env_with_file_fallback(*env_vars: str) -> str | None:
     for env_var in env_vars:
         if env_var in file_values:
             return file_values[env_var]
+    for env_var in env_vars:
         value = os.getenv(env_var)
         if value:
             return value
@@ -108,17 +109,17 @@ def get_settings() -> Settings:
     """Return the cached application settings instance."""
 
     settings = Settings()
-    if not settings.openai_api_key:
-        value = _load_env_with_file_fallback(
-            "PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"
-        )
-        if value:
-            settings.openai_api_key = value
-    if not settings.openai_project:
-        value = _load_env_with_file_fallback(
-            "PROSTE_PRAWO_OPENAI_PROJECT", "OPENAI_PROJECT"
-        )
-        if value:
-            settings.openai_project = value
+
+    value = _load_env_with_file_fallback(
+        "PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"
+    )
+    if value:
+        settings.openai_api_key = value
+
+    value = _load_env_with_file_fallback(
+        "PROSTE_PRAWO_OPENAI_PROJECT", "OPENAI_PROJECT"
+    )
+    if value:
+        settings.openai_project = value
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     return settings

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -75,7 +75,7 @@ def test_client_prefers_env_file_over_environment(monkeypatch, tmp_path):
     env_file.write_text("OPENAI_API_KEY=from_file\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OPENAI_API_KEY", "from_env")
-    monkeypatch.delenv("PROSTE_PRAWO_OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("PROSTE_PRAWO_OPENAI_API_KEY", "from_pref_env")
     get_settings.cache_clear()
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- ensure `.env` values override prefixed OpenAI settings by loading file-backed values after instantiating `Settings`
- adjust OpenAI client tests to cover scenarios where prefixed environment variables are set but the `.env` file should win

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e071a935388326b97444d13b39e923