### PR TITLE
Add env file configuration to backend compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: backend/Dockerfile
     ports:
       - "8000:8000"
+    env_file:
+      - .env
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
     volumes:


### PR DESCRIPTION
## Summary
- add the repository .env file to the backend service via env_file so the container can access environment variables

## Testing
- docker compose up -d --build backend *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e160bc80dc832695102cc2917a9ab9