### PR TITLE
Load OpenAI credentials solely from repository env file

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,6 @@
 """Application-wide configuration and settings."""
 from __future__ import annotations
 
-import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -80,27 +79,25 @@ def _resolve_env_path() -> Path | None:
     return None
 
 
-def _load_env_with_file_fallback(*env_vars: str) -> str | None:
-    """Return the first available value preferring the ``.env`` file."""
+def _load_from_env_file(*env_vars: str) -> str | None:
+    """Return the first available value found in the project's ``.env`` file."""
 
     env_path = _resolve_env_path()
+    if env_path is None or not env_path.exists():
+        return None
+
     file_values: dict[str, str] = {}
-    if env_path is not None:
-        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, raw_value = line.split("=", 1)
-            candidate = raw_value.strip().strip('"').strip("'")
-            if candidate:
-                file_values[key.strip()] = candidate
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        candidate = raw_value.strip().strip('"').strip("'")
+        if candidate:
+            file_values[key.strip()] = candidate
     for env_var in env_vars:
         if env_var in file_values:
             return file_values[env_var]
-    for env_var in env_vars:
-        value = os.getenv(env_var)
-        if value:
-            return value
     return None
 
 
@@ -110,16 +107,10 @@ def get_settings() -> Settings:
 
     settings = Settings()
 
-    value = _load_env_with_file_fallback(
-        "PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY"
-    )
-    if value:
-        settings.openai_api_key = value
+    value = _load_from_env_file("PROSTE_PRAWO_OPENAI_API_KEY", "OPENAI_API_KEY")
+    settings.openai_api_key = value
 
-    value = _load_env_with_file_fallback(
-        "PROSTE_PRAWO_OPENAI_PROJECT", "OPENAI_PROJECT"
-    )
-    if value:
-        settings.openai_project = value
+    value = _load_from_env_file("PROSTE_PRAWO_OPENAI_PROJECT", "OPENAI_PROJECT")
+    settings.openai_project = value
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     return settings

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -29,7 +29,7 @@ class OpenAIClient:
             api_key = settings.openai_api_key
             if not api_key:
                 raise RuntimeError(
-                    "OpenAI API key is missing. Set OPENAI_API_KEY or PROSTE_PRAWO_OPENAI_API_KEY."
+                    "OpenAI API key is missing. Define OPENAI_API_KEY in the project .env file."
                 )
             client_kwargs = {"api_key": api_key}
             openai_project = settings.openai_project

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -70,7 +70,7 @@ def test_client_uses_api_key_from_env(monkeypatch, tmp_path):
     assert captured.get("kwargs", {}).get("api_key") == "from_env"
 
 
-def test_client_prefers_env_file_over_environment(monkeypatch, tmp_path):
+def test_client_ignores_host_environment(monkeypatch, tmp_path):
     env_file = tmp_path / ".env"
     env_file.write_text("OPENAI_API_KEY=from_file\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
@@ -95,10 +95,15 @@ def test_client_prefers_env_file_over_environment(monkeypatch, tmp_path):
     assert captured.get("kwargs", {}).get("api_key") == "from_file"
 
 
-def test_client_passes_project_when_available(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "from_env")
-    monkeypatch.setenv("OPENAI_PROJECT", "project-123")
+def test_client_passes_project_when_available(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "OPENAI_API_KEY=from_file\nOPENAI_PROJECT=project-123\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("PROSTE_PRAWO_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_PROJECT", raising=False)
     monkeypatch.delenv("PROSTE_PRAWO_OPENAI_PROJECT", raising=False)
     get_settings.cache_clear()
     captured: dict[str, object] = {}
@@ -117,7 +122,7 @@ def test_client_passes_project_when_available(monkeypatch):
     finally:
         get_settings.cache_clear()
 
-    assert captured.get("kwargs", {}).get("api_key") == "from_env"
+    assert captured.get("kwargs", {}).get("api_key") == "from_file"
     assert captured.get("kwargs", {}).get("project") == "project-123"
 
 


### PR DESCRIPTION
## Summary
- stop falling back to host environment variables when resolving OpenAI credentials
- clarify the OpenAI client error message to reference the project .env file
- update OpenAI client tests to cover the new behaviour and rely on .env fixtures

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1678e2dd88326a5c9e0162a5232ee