### PR TITLE
Add read-only secrets volume for backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
     volumes:
       - ./data:/app/data
+      - ./.env:/app/.env:ro


### PR DESCRIPTION
## Summary
- mount the repository's .env file into /app/.env as read-only for the backend container

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e18b2de8e8832690d5f9ddd27ae8c9