### PR TITLE
Handle fenced JSON responses in OpenAI client

### DIFF
--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -16,6 +16,23 @@ from .ingestion import DocumentSection
 logger = logging.getLogger(__name__)
 
 
+def _normalise_json_content(content: str) -> str:
+    """Return content stripped of common Markdown fences."""
+
+    cleaned = content.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.splitlines()
+        if lines:
+            # Drop opening fence such as ``` or ```json
+            first_line = lines[0].strip()
+            if first_line.startswith("```"):
+                lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        cleaned = "\n".join(lines).strip()
+    return cleaned
+
+
 class OpenAIClientError(RuntimeError):
     """Raised when the OpenAI client fails to generate a valid response."""
 
@@ -234,8 +251,9 @@ class OpenAIClient:
 
     def _complete_json(self, messages: list[dict[str, str]], *, max_tokens: int = 512) -> Any:
         content = self._complete(messages, max_tokens=max_tokens)
+        normalised = _normalise_json_content(content)
         try:
-            parsed = json.loads(content)
+            parsed = json.loads(normalised)
             return parsed
         except json.JSONDecodeError as exc:
             logger.error("Failed to decode OpenAI JSON response: %s", content, exc_info=True)

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -138,3 +138,25 @@ def test_client_requires_api_key(monkeypatch, tmp_path):
             OpenAIClient()
     finally:
         get_settings.cache_clear()
+
+
+def test_extract_items_handles_markdown_json_response():
+    response_content = """```json
+    [\n  \"Pierwszy\",\n  \"Drugi\"\n]
+    ```"""
+
+    class _SuccessCompletions:
+        def create(self, **_: object):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=response_content)
+                    )
+                ]
+            )
+
+    client = OpenAIClient(client=SimpleNamespace(chat=SimpleNamespace(completions=_SuccessCompletions())))
+
+    result = client.extract_items("Tekst", "Kategorie")
+
+    assert result == ["Pierwszy", "Drugi"]


### PR DESCRIPTION
## Summary
- add a helper to normalise JSON payloads returned by the OpenAI client
- strip markdown fences before decoding JSON responses
- extend the OpenAI client tests to cover fenced JSON replies

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1989d05ac8326b1904eb58f5d044b