### PR TITLE
Add LLM usage metrics tracking and reader cost panel

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
+from typing import Dict
 
 try:  # pragma: no cover - compatibility with Pydantic v1
     from pydantic import AliasChoices, Field
@@ -63,6 +64,13 @@ class Settings(BaseSettings):
             if AliasChoices is not None
             else {}
         ),
+    )
+    openai_pricing: Dict[str, Dict[str, float]] = Field(
+        default_factory=lambda: {
+            "gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006},
+            "default": {"prompt": 0.0004, "completion": 0.0008},
+        },
+        description="Per-model pricing (USD) per 1K prompt/completion tokens.",
     )
 
 

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -10,6 +10,23 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, Field
 
 
+class DocumentUsageMetrics(BaseModel):
+    """Aggregate usage statistics for LLM calls executed per document."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost_usd: float = 0.0
+
+    def accumulate(self, other: "DocumentUsageMetrics") -> None:
+        """Add values from ``other`` to the current metrics in place."""
+
+        self.prompt_tokens += other.prompt_tokens
+        self.completion_tokens += other.completion_tokens
+        self.total_tokens += other.total_tokens
+        self.cost_usd += other.cost_usd
+
+
 class SectionSimplification(BaseModel):
     """Plain-language representation of a document fragment."""
 
@@ -62,6 +79,7 @@ class DocumentMetadata(BaseModel):
     simplified_sections: list[SectionSimplification] = Field(default_factory=list)
     definitions: list[DocumentDefinition] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
+    token_usage: DocumentUsageMetrics = Field(default_factory=DocumentUsageMetrics)
 
     def to_public(self) -> "DocumentMetadataPublic":
         """Expose a sanitized view suitable for API responses."""
@@ -80,6 +98,7 @@ class DocumentMetadata(BaseModel):
             simplified_sections=list(self.simplified_sections),
             definitions=list(self.definitions),
             extra=dict(self.extra),
+            token_usage=DocumentUsageMetrics(**self.token_usage.dict()),
         )
 
 
@@ -99,6 +118,7 @@ class DocumentMetadataPublic(BaseModel):
     simplified_sections: list[SectionSimplification] = Field(default_factory=list)
     definitions: list[DocumentDefinition] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
+    token_usage: DocumentUsageMetrics = Field(default_factory=DocumentUsageMetrics)
 
 
 class DocumentCreateResponse(BaseModel):

--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -7,7 +7,23 @@ import textwrap
 from typing import Iterable
 
 from ..core.config import get_settings
-from ..models.documents import DocumentDefinition, SectionSimplification
+from ..models.documents import DocumentDefinition, DocumentUsageMetrics, SectionSimplification
+
+
+def _usage_from_payload(payload: dict[str, int] | None) -> DocumentUsageMetrics:
+    prompt = int(payload.get("prompt_tokens", 0)) if payload else 0
+    completion = int(payload.get("completion_tokens", 0)) if payload else 0
+    total_value = payload.get("total_tokens") if payload else None
+    total = int(total_value) if total_value is not None else prompt + completion
+    return DocumentUsageMetrics(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=total,
+    )
+
+
+def _zero_usage() -> DocumentUsageMetrics:
+    return DocumentUsageMetrics()
 from .indexing import RetrievedChunk
 from .ingestion import DocumentSection
 from .openai_client import OpenAIClientError, get_openai_client
@@ -37,18 +53,18 @@ def _build_summary_local(text: str) -> str:
     return first
 
 
-def build_summary(text: str, use_cloud: bool | None = None) -> str:
+def build_summary(text: str, use_cloud: bool | None = None) -> tuple[str, DocumentUsageMetrics]:
     """Return a short summary, preferring OpenAI when available."""
 
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
-            summary = client.summarise(text)
+            summary, usage = client.summarise(text)
             if summary:
-                return summary
+                return summary, _usage_from_payload(usage)
         except OpenAIClientError:
             pass
-    return _build_summary_local(text)
+    return _build_summary_local(text), _zero_usage()
 
 
 def _collect_sentences(text: str, keywords: Iterable[str]) -> list[str]:
@@ -63,52 +79,52 @@ def _collect_sentences(text: str, keywords: Iterable[str]) -> list[str]:
     return sentences
 
 
-def extract_obligations(text: str, use_cloud: bool | None = None) -> list[str]:
+def extract_obligations(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
-            obligations = client.extract_items(text, "obowiązki")
+            obligations, usage = client.extract_items(text, "obowiązki")
             if obligations:
-                return obligations
+                return obligations, _usage_from_payload(usage)
         except OpenAIClientError:
             pass
-    return _collect_sentences(text, ["zobowiąz", "obowiąz", "należy"])
+    return _collect_sentences(text, ["zobowiąz", "obowiąz", "należy"]), _zero_usage()
 
 
-def extract_penalties(text: str, use_cloud: bool | None = None) -> list[str]:
+def extract_penalties(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
-            penalties = client.extract_items(text, "kary lub sankcje")
+            penalties, usage = client.extract_items(text, "kary lub sankcje")
             if penalties:
-                return penalties
+                return penalties, _usage_from_payload(usage)
         except OpenAIClientError:
             pass
-    return _collect_sentences(text, ["kara", "odpowiedzialn", "grzywna"])
+    return _collect_sentences(text, ["kara", "odpowiedzialn", "grzywna"]), _zero_usage()
 
 
-def extract_deadlines(text: str, use_cloud: bool | None = None) -> list[str]:
+def extract_deadlines(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
-            deadlines = client.extract_items(text, "terminy lub daty graniczne")
+            deadlines, usage = client.extract_items(text, "terminy lub daty graniczne")
             if deadlines:
-                return deadlines
+                return deadlines, _usage_from_payload(usage)
         except OpenAIClientError:
             pass
-    return _collect_sentences(text, ["termin", "dni", "miesiąc", "miesiac"])
+    return _collect_sentences(text, ["termin", "dni", "miesiąc", "miesiac"]), _zero_usage()
 
 
-def extract_risks(text: str, use_cloud: bool | None = None) -> list[str]:
+def extract_risks(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
-            risks = client.extract_items(text, "ryzyka dla stron umowy")
+            risks, usage = client.extract_items(text, "ryzyka dla stron umowy")
             if risks:
-                return risks
+                return risks, _usage_from_payload(usage)
         except OpenAIClientError:
             pass
-    return _collect_sentences(text, ["ryzyk", "zagroż", "niebezpiecz", "utrata", "szkody"])
+    return _collect_sentences(text, ["ryzyk", "zagroż", "niebezpiecz", "utrata", "szkody"]), _zero_usage()
 
 
 def answer_question(
@@ -117,7 +133,7 @@ def answer_question(
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
-            result = client.answer_question(question, retrieved_chunks)
+            result, _usage = client.answer_question(question, retrieved_chunks)
             content = str(result.get("answer", "")).strip()
             if content:
                 sources = [str(source) for source in result.get("sources", []) if str(source).strip()]
@@ -168,14 +184,14 @@ _REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
 
 def simplify_sections(
     sections: Iterable[DocumentSection], use_cloud: bool | None = None
-) -> list[SectionSimplification]:
+) -> tuple[list[SectionSimplification], DocumentUsageMetrics]:
     """Generate plain-language explanations using OpenAI when enabled."""
 
     section_list = list(sections)
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
-            ai_results = client.simplify_sections(section_list)
+            ai_results, usage = client.simplify_sections(section_list)
             mapped = {section.identifier: section for section in section_list}
             simplifications: list[SectionSimplification] = []
             for item in ai_results:
@@ -196,10 +212,10 @@ def simplify_sections(
                     )
                 )
             if simplifications:
-                return simplifications
+                return simplifications, _usage_from_payload(usage)
         except OpenAIClientError:
             pass
-    return _simplify_sections_local(section_list)
+    return _simplify_sections_local(section_list), _zero_usage()
 
 
 def _simplify_sections_local(sections: Iterable[DocumentSection]) -> list[SectionSimplification]:

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -57,7 +57,7 @@ class OpenAIClient:
             self._client = client
         self._model = settings.openai_model
 
-    def summarise(self, text: str) -> str:
+    def summarise(self, text: str) -> tuple[str, dict[str, int]]:
         logger.debug("Requesting OpenAI summary (%d chars)", len(text))
         messages = [
             {
@@ -75,11 +75,11 @@ class OpenAIClient:
                 ),
             },
         ]
-        summary = self._complete(messages, max_tokens=300)
+        summary, usage = self._complete(messages, max_tokens=300)
         logger.debug("Received OpenAI summary response (%d chars)", len(summary))
-        return summary
+        return summary, usage
 
-    def extract_items(self, text: str, category: str) -> list[str]:
+    def extract_items(self, text: str, category: str) -> tuple[list[str], dict[str, int]]:
         logger.debug("Requesting OpenAI extraction for '%s' (%d chars)", category, len(text))
         messages = [
             {
@@ -98,7 +98,7 @@ class OpenAIClient:
                 ),
             },
         ]
-        data = self._complete_json(messages, max_tokens=400)
+        data, usage = self._complete_json(messages, max_tokens=400)
         logger.debug(
             "Received OpenAI extraction response for '%s': %s",
             category,
@@ -113,9 +113,11 @@ class OpenAIClient:
             value = item.strip()
             if value:
                 cleaned.append(value)
-        return cleaned
+        return cleaned, usage
 
-    def simplify_sections(self, sections: Iterable[DocumentSection]) -> list[dict[str, str]]:
+    def simplify_sections(
+        self, sections: Iterable[DocumentSection]
+    ) -> tuple[list[dict[str, str]], dict[str, int]]:
         payload = [
             {
                 "identifier": section.identifier,
@@ -141,7 +143,7 @@ class OpenAIClient:
             },
         ]
         logger.debug("Requesting OpenAI simplification for %d sections", len(payload))
-        data = self._complete_json(messages, max_tokens=1200)
+        data, usage = self._complete_json(messages, max_tokens=1200)
         if isinstance(data, list):
             logger.debug("Received OpenAI simplification response with %d items", len(data))
         else:
@@ -167,11 +169,11 @@ class OpenAIClient:
                 )
         if not results:
             raise OpenAIClientError("Brak poprawnych uproszczeń w odpowiedzi LLM.")
-        return results
+        return results, usage
 
     def answer_question(
         self, question: str, retrieved_chunks: Iterable[RetrievedChunk]
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], dict[str, int]]:
         context = [
             {
                 "identifier": chunk.identifier,
@@ -204,7 +206,7 @@ class OpenAIClient:
             len(question),
             len(context),
         )
-        data = self._complete_json(messages, max_tokens=600)
+        data, usage = self._complete_json(messages, max_tokens=600)
         logger.debug("Received OpenAI answer response: %s", data)
         if not isinstance(data, dict):
             raise OpenAIClientError("Niepoprawny format odpowiedzi dla Q&A.")
@@ -216,9 +218,15 @@ class OpenAIClient:
             sources = []
         if not answer:
             raise OpenAIClientError("Brak treści odpowiedzi Q&A.")
-        return {"answer": answer, "sources": sources}
+        return {"answer": answer, "sources": sources}, usage
 
-    def _complete(self, messages: list[dict[str, str]], *, max_tokens: int = 512, temperature: float = 0.2) -> str:
+    def _complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        max_tokens: int = 512,
+        temperature: float = 0.2,
+    ) -> tuple[str, dict[str, int]]:
         try:
             logger.debug(
                 "Calling OpenAI chat completion (model=%s, max_tokens=%d, temperature=%.2f)",
@@ -247,14 +255,22 @@ class OpenAIClient:
         if not content:
             logger.error("OpenAI response message missing content")
             raise OpenAIClientError("Odpowiedź OpenAI nie zawiera treści.")
-        return str(content).strip()
+        usage_data = getattr(response, "usage", None)
+        usage: dict[str, int] = {
+            "prompt_tokens": int(getattr(usage_data, "prompt_tokens", 0) or 0),
+            "completion_tokens": int(getattr(usage_data, "completion_tokens", 0) or 0),
+            "total_tokens": int(getattr(usage_data, "total_tokens", 0) or 0),
+        }
+        return str(content).strip(), usage
 
-    def _complete_json(self, messages: list[dict[str, str]], *, max_tokens: int = 512) -> Any:
-        content = self._complete(messages, max_tokens=max_tokens)
+    def _complete_json(
+        self, messages: list[dict[str, str]], *, max_tokens: int = 512
+    ) -> tuple[Any, dict[str, int]]:
+        content, usage = self._complete(messages, max_tokens=max_tokens)
         normalised = _normalise_json_content(content)
         try:
             parsed = json.loads(normalised)
-            return parsed
+            return parsed, usage
         except json.JSONDecodeError as exc:
             logger.error("Failed to decode OpenAI JSON response: %s", content, exc_info=True)
             raise OpenAIClientError("Nie udało się zinterpretować odpowiedzi jako JSON.") from exc

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -16,6 +16,7 @@ from ..core.config import get_settings
 from ..models.documents import (
     DocumentMetadata,
     DocumentProcessingStatus,
+    DocumentUsageMetrics,
     SectionSimplification,
 )
 from ..repositories import DocumentRepository
@@ -136,34 +137,106 @@ class DocumentPipeline:
             logger.info("Indexed sanitised sections for %s", document_id)
 
             use_cloud = self._settings.enable_cloud_llm
+            usage_totals = DocumentUsageMetrics()
             try:
                 logger.info(
                     "Running inference for %s using %s models",
                     document_id,
                     "OpenAI" if use_cloud else "local",
                 )
-                metadata.summary = inference.build_summary(sanitized.text, use_cloud=use_cloud)
-                metadata.obligations = inference.extract_obligations(sanitized.text, use_cloud=use_cloud)
-                metadata.penalties = inference.extract_penalties(sanitized.text, use_cloud=use_cloud)
-                metadata.deadlines = inference.extract_deadlines(sanitized.text, use_cloud=use_cloud)
-                metadata.risks = inference.extract_risks(sanitized.text, use_cloud=use_cloud)
-                metadata.simplified_sections = inference.simplify_sections(
+                summary, summary_usage = inference.build_summary(
+                    sanitized.text, use_cloud=use_cloud
+                )
+                metadata.summary = summary
+                usage_totals.accumulate(summary_usage)
+
+                obligations, obligations_usage = inference.extract_obligations(
+                    sanitized.text, use_cloud=use_cloud
+                )
+                metadata.obligations = obligations
+                usage_totals.accumulate(obligations_usage)
+
+                penalties, penalties_usage = inference.extract_penalties(
+                    sanitized.text, use_cloud=use_cloud
+                )
+                metadata.penalties = penalties
+                usage_totals.accumulate(penalties_usage)
+
+                deadlines, deadlines_usage = inference.extract_deadlines(
+                    sanitized.text, use_cloud=use_cloud
+                )
+                metadata.deadlines = deadlines
+                usage_totals.accumulate(deadlines_usage)
+
+                risks, risks_usage = inference.extract_risks(
+                    sanitized.text, use_cloud=use_cloud
+                )
+                metadata.risks = risks
+                usage_totals.accumulate(risks_usage)
+
+                simplified, simplified_usage = inference.simplify_sections(
                     sanitized_sections, use_cloud=use_cloud
                 )
+                metadata.simplified_sections = simplified
+                usage_totals.accumulate(simplified_usage)
             except OpenAIClientError:
                 logger.warning(
                     "Falling back to local inference for %s due to OpenAI failure",
                     document_id,
                     exc_info=True,
                 )
-                metadata.summary = inference.build_summary(sanitized.text, use_cloud=False)
-                metadata.obligations = inference.extract_obligations(sanitized.text, use_cloud=False)
-                metadata.penalties = inference.extract_penalties(sanitized.text, use_cloud=False)
-                metadata.deadlines = inference.extract_deadlines(sanitized.text, use_cloud=False)
-                metadata.risks = inference.extract_risks(sanitized.text, use_cloud=False)
-                metadata.simplified_sections = inference.simplify_sections(
+                summary, summary_usage = inference.build_summary(
+                    sanitized.text, use_cloud=False
+                )
+                metadata.summary = summary
+                usage_totals.accumulate(summary_usage)
+
+                obligations, obligations_usage = inference.extract_obligations(
+                    sanitized.text, use_cloud=False
+                )
+                metadata.obligations = obligations
+                usage_totals.accumulate(obligations_usage)
+
+                penalties, penalties_usage = inference.extract_penalties(
+                    sanitized.text, use_cloud=False
+                )
+                metadata.penalties = penalties
+                usage_totals.accumulate(penalties_usage)
+
+                deadlines, deadlines_usage = inference.extract_deadlines(
+                    sanitized.text, use_cloud=False
+                )
+                metadata.deadlines = deadlines
+                usage_totals.accumulate(deadlines_usage)
+
+                risks, risks_usage = inference.extract_risks(
+                    sanitized.text, use_cloud=False
+                )
+                metadata.risks = risks
+                usage_totals.accumulate(risks_usage)
+
+                simplified, simplified_usage = inference.simplify_sections(
                     sanitized_sections, use_cloud=False
                 )
+                metadata.simplified_sections = simplified
+                usage_totals.accumulate(simplified_usage)
+            if usage_totals.total_tokens == 0 and (
+                usage_totals.prompt_tokens or usage_totals.completion_tokens
+            ):
+                usage_totals.total_tokens = (
+                    usage_totals.prompt_tokens + usage_totals.completion_tokens
+                )
+            pricing = self._settings.openai_pricing.get(
+                self._settings.openai_model
+            ) or self._settings.openai_pricing.get("default", {})
+            prompt_rate = float(pricing.get("prompt", 0.0))
+            completion_rate = float(pricing.get("completion", 0.0))
+            cost = (
+                (usage_totals.prompt_tokens / 1000) * prompt_rate
+                + (usage_totals.completion_tokens / 1000) * completion_rate
+            )
+            usage_totals.cost_usd = round(cost, 6)
+            metadata.token_usage = usage_totals
             metadata.definitions = inference.extract_definitions(sanitized.text)
             metadata.status = DocumentProcessingStatus.READY
             self.repository.upsert(metadata)

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -106,6 +106,13 @@ def test_pipeline_generates_metadata_and_answers_questions(client_and_modules):
     assert "source_path" not in data
     assert "sanitized_path" not in data
     assert "pii_secret_path" not in data
+    assert "token_usage" in data
+    assert set(data["token_usage"].keys()) == {
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cost_usd",
+    }
     serialized = json.dumps(data)
     assert "biuro@example.com" not in serialized
 
@@ -175,6 +182,13 @@ def test_document_listing_does_not_expose_paths(client_and_modules):
         assert "sanitized_path" not in entry
         assert "pii_secret_path" not in entry
         assert "risks" in entry
+        assert "token_usage" in entry
+        assert set(entry["token_usage"].keys()) == {
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "cost_usd",
+        }
 
 
 def test_repository_survives_restart(client_and_modules):

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -157,6 +157,7 @@ def test_extract_items_handles_markdown_json_response():
 
     client = OpenAIClient(client=SimpleNamespace(chat=SimpleNamespace(completions=_SuccessCompletions())))
 
-    result = client.extract_items("Tekst", "Kategorie")
+    result, usage = client.extract_items("Tekst", "Kategorie")
 
     assert result == ["Pierwszy", "Drugi"]
+    assert usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}

--- a/backend/tests/test_pipeline_llm.py
+++ b/backend/tests/test_pipeline_llm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 from unittest.mock import patch
@@ -61,38 +61,66 @@ class DummySettings:
     enable_cloud_llm: bool
     llm_provider: str = "openai"
     openai_model: str = "gpt-test"
+    openai_pricing: dict[str, dict[str, float]] = field(
+        default_factory=lambda: {
+            "gpt-test": {"prompt": 0.001, "completion": 0.002},
+            "default": {"prompt": 0.001, "completion": 0.002},
+        }
+    )
 
 
 class DummyOpenAIClient:
     def __init__(self) -> None:
         self.calls: list[tuple[str, object]] = []
 
-    def summarise(self, text: str) -> str:
+    def summarise(self, text: str) -> tuple[str, dict[str, int]]:
         self.calls.append(("summarise", text))
-        return "Streszczenie z chmury"
+        return "Streszczenie z chmury", {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        }
 
-    def extract_items(self, text: str, category: str) -> list[str]:
+    def extract_items(self, text: str, category: str) -> tuple[list[str], dict[str, int]]:
         self.calls.append(("extract_items", category))
-        return [f"AI {category}"]
+        return [f"AI {category}"], {
+            "prompt_tokens": 20,
+            "completion_tokens": 10,
+            "total_tokens": 30,
+        }
 
-    def simplify_sections(self, sections: Iterable[DocumentSection]) -> list[dict[str, str]]:
+    def simplify_sections(
+        self, sections: Iterable[DocumentSection]
+    ) -> tuple[list[dict[str, str]], dict[str, int]]:
         sections = list(sections)
         self.calls.append(("simplify_sections", [section.identifier for section in sections]))
-        return [
+        return (
+            [
+                {
+                    "identifier": section.identifier,
+                    "plain_language": f"Uproszczenie {section.identifier}",
+                    "source_excerpt": "fragment",
+                }
+                for section in sections
+            ],
             {
-                "identifier": section.identifier,
-                "plain_language": f"Uproszczenie {section.identifier}",
-                "source_excerpt": "fragment",
-            }
-            for section in sections
-        ]
+                "prompt_tokens": 50,
+                "completion_tokens": 25,
+                "total_tokens": 75,
+            },
+        )
 
-    def answer_question(self, question: str, retrieved_chunks: Iterable[RetrievedChunk]):
+    def answer_question(
+        self, question: str, retrieved_chunks: Iterable[RetrievedChunk]
+    ) -> tuple[dict[str, object], dict[str, int]]:
         self.calls.append(("answer_question", question))
-        return {
-            "answer": "Odpowiedź z chmury",
-            "sources": [chunk.identifier for chunk in retrieved_chunks],
-        }
+        return (
+            {
+                "answer": "Odpowiedź z chmury",
+                "sources": [chunk.identifier for chunk in retrieved_chunks],
+            },
+            {"prompt_tokens": 15, "completion_tokens": 10, "total_tokens": 25},
+        )
 
 
 def _setup_documents(tmp_path: Path) -> tuple[InMemoryRepository, DummyIndexer, DocumentMetadata]:
@@ -140,6 +168,10 @@ def test_run_pipeline_uses_openai_when_enabled(tmp_path):
     assert processed.deadlines == ["AI terminy lub daty graniczne"]
     assert processed.risks == ["AI ryzyka dla stron umowy"]
     assert all(section.plain_language.startswith("Uproszczenie") for section in processed.simplified_sections)
+    assert processed.token_usage.prompt_tokens == 140
+    assert processed.token_usage.completion_tokens == 70
+    assert processed.token_usage.total_tokens == 210
+    assert processed.token_usage.cost_usd == pytest.approx(0.00028)
     called_operations = [name for name, _ in client.calls]
     assert "summarise" in called_operations
     assert "simplify_sections" in called_operations
@@ -171,6 +203,10 @@ def test_run_pipeline_uses_heuristics_when_cloud_disabled(tmp_path):
     assert processed.obligations == ["Należy zapłacić karę do 7 dni."]
     assert processed.penalties == ["Należy zapłacić karę do 7 dni."]
     assert processed.deadlines == ["Należy zapłacić karę do 7 dni."]
+    assert processed.token_usage.prompt_tokens == 0
+    assert processed.token_usage.completion_tokens == 0
+    assert processed.token_usage.total_tokens == 0
+    assert processed.token_usage.cost_usd == 0
 
 
 def test_answer_question_uses_openai_when_enabled(tmp_path):

--- a/frontend/src/components/CostOverviewPanel.tsx
+++ b/frontend/src/components/CostOverviewPanel.tsx
@@ -1,0 +1,57 @@
+import type { TokenUsageMetrics } from '../types';
+
+interface CostOverviewPanelProps {
+  usage?: TokenUsageMetrics;
+  isReady: boolean;
+}
+
+const defaultUsage: TokenUsageMetrics = {
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  total_tokens: 0,
+  cost_usd: 0
+};
+
+const CostOverviewPanel = ({ usage, isReady }: CostOverviewPanelProps) => {
+  const metrics = usage ?? defaultUsage;
+  const formattedCost = metrics.cost_usd.toLocaleString('pl-PL', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 6
+  });
+
+  const cards = [
+    { label: 'Tokeny promptu', value: metrics.prompt_tokens.toLocaleString('pl-PL') },
+    { label: 'Tokeny odpowiedzi', value: metrics.completion_tokens.toLocaleString('pl-PL') },
+    { label: 'Tokeny łącznie', value: metrics.total_tokens.toLocaleString('pl-PL') },
+    { label: 'Szacowany koszt', value: formattedCost }
+  ];
+
+  return (
+    <section className="cost-overview panel">
+      <div className="cost-overview-header">
+        <h2>Zużycie tokenów</h2>
+        <span className={`cost-overview-badge ${isReady ? 'ready' : 'pending'}`}>
+          {isReady ? 'Aktualne' : 'W trakcie'}
+        </span>
+      </div>
+      <p className="cost-overview-subtitle">
+        Monitoruj liczbę tokenów oraz orientacyjny koszt przetwarzania dokumentu przez OpenAI.
+      </p>
+      <div className="cost-overview-grid">
+        {cards.map((card) => (
+          <div key={card.label} className="cost-card">
+            <span className="cost-card-value">{card.value}</span>
+            <span className="cost-card-label">{card.label}</span>
+          </div>
+        ))}
+      </div>
+      {!isReady && (
+        <p className="cost-overview-hint">Metryki pojawią się po zakończeniu przetwarzania dokumentu.</p>
+      )}
+    </section>
+  );
+};
+
+export default CostOverviewPanel;

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -3,7 +3,12 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { API_BASE_URL } from '../config';
 import SectionViewer from '../components/SectionViewer';
 import QaModal from '../components/QaModal';
-import type { DocumentMetadataPublic, SectionSimplification, SimplifiedResponse } from '../types';
+import CostOverviewPanel from '../components/CostOverviewPanel';
+import type {
+  DocumentMetadataPublic,
+  SectionSimplification,
+  SimplifiedResponse
+} from '../types';
 
 function ReaderPage() {
   const { documentId } = useParams();
@@ -110,6 +115,7 @@ function ReaderPage() {
             onSelect={setActiveSection}
           />
           <aside className="reader-insights">
+            <CostOverviewPanel usage={metadata?.token_usage} isReady={ready} />
             <h2>Najważniejsze informacje</h2>
             {insights.map((group) => (
               <div key={group.label}>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -113,6 +113,79 @@ body {
   font-size: 0.95rem;
 }
 
+.cost-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cost-overview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cost-overview-subtitle {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.cost-overview-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.cost-card {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.14), rgba(99, 102, 241, 0.12));
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.cost-card-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.cost-card-label {
+  font-size: 0.85rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cost-overview-badge {
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cost-overview-badge.ready {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.cost-overview-badge.pending {
+  background: rgba(249, 115, 22, 0.18);
+  color: #9a3412;
+}
+
+.cost-overview-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
 button,
 .button,
 .button-link,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,13 @@ export interface SectionSimplification {
   plain_language: string;
 }
 
+export interface TokenUsageMetrics {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
 export interface DocumentMetadataPublic {
   document_id: string;
   title: string;
@@ -18,6 +25,7 @@ export interface DocumentMetadataPublic {
   deadlines: string[];
   risks: string[];
   simplified_sections: SectionSimplification[];
+  token_usage: TokenUsageMetrics;
 }
 
 export interface DocumentListItem extends DocumentMetadataPublic {}


### PR DESCRIPTION
## Summary
- capture per-document LLM token usage and cost using configurable pricing in the pipeline metadata
- propagate usage metrics through the OpenAI client and inference helpers with updated backend tests
- expose the new token and cost data in the reader UI via a cost overview panel and supporting styles/types

## Testing
- pytest backend/tests *(fails: environment lacks the `pydantic` dependency required by backend models)*

------
https://chatgpt.com/codex/tasks/task_e_68e19b4516a083268e2caceef9ce0147