### PR TITLE
Handle truncated OpenAI responses and show document token usage

### DIFF
--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -250,8 +250,21 @@ class OpenAIClient:
         if not choices:
             logger.error("OpenAI response did not include choices")
             raise OpenAIClientError("OpenAI nie zwróciło żadnych wyników.")
-        message = choices[0].message
+        choice = choices[0]
+        message = getattr(choice, "message", None)
         content = getattr(message, "content", None)
+        finish_reason = getattr(choice, "finish_reason", None)
+        if finish_reason and finish_reason != "stop":
+            normalised_content = _normalise_json_content(str(content or ""))
+            logger.error(
+                "OpenAI response ended with finish_reason=%s. Raw content: %s\nNormalised content: %s",
+                finish_reason,
+                content,
+                normalised_content,
+            )
+            raise OpenAIClientError(
+                "OpenAI zakończyło generowanie odpowiedzi przedwcześnie."
+            )
         if not content:
             logger.error("OpenAI response message missing content")
             raise OpenAIClientError("Odpowiedź OpenAI nie zawiera treści.")
@@ -272,7 +285,12 @@ class OpenAIClient:
             parsed = json.loads(normalised)
             return parsed, usage
         except json.JSONDecodeError as exc:
-            logger.error("Failed to decode OpenAI JSON response: %s", content, exc_info=True)
+            logger.error(
+                "Failed to decode OpenAI JSON response. Raw content: %s\nNormalised content: %s",
+                content,
+                normalised,
+                exc_info=True,
+            )
             raise OpenAIClientError("Nie udało się zinterpretować odpowiedzi jako JSON.") from exc
 
 

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -161,3 +161,30 @@ def test_extract_items_handles_markdown_json_response():
 
     assert result == ["Pierwszy", "Drugi"]
     assert usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+def test_complete_json_raises_on_truncated_response(caplog):
+    response_content = "[\"Niedokonczona odpowiedz"
+
+    class _LengthCompletions:
+        def create(self, **_: object):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=response_content),
+                        finish_reason="length",
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+            )
+
+    client = OpenAIClient(
+        client=SimpleNamespace(chat=SimpleNamespace(completions=_LengthCompletions()))
+    )
+
+    with caplog.at_level(logging.ERROR), pytest.raises(OpenAIClientError):
+        client._complete_json([{"role": "user", "content": "Test"}])
+
+    error_messages = [record.message for record in caplog.records if record.levelno == logging.ERROR]
+    assert any("finish_reason=length" in message for message in error_messages)
+    assert any(response_content in message for message in error_messages)

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -8,6 +8,16 @@ interface DocumentListProps {
 }
 
 function DocumentList({ documents, isLoading, onRefresh }: DocumentListProps) {
+  const formatNumber = (value: number | undefined | null) =>
+    typeof value === 'number' && Number.isFinite(value)
+      ? value.toLocaleString('pl-PL')
+      : '—';
+
+  const formatCurrency = (value: number | undefined | null) =>
+    typeof value === 'number' && Number.isFinite(value)
+      ? value.toLocaleString('pl-PL', { style: 'currency', currency: 'USD' })
+      : '—';
+
   return (
     <section className="panel">
       <header className="panel-header">
@@ -21,11 +31,33 @@ function DocumentList({ documents, isLoading, onRefresh }: DocumentListProps) {
       <ul className="document-list">
         {documents.map((document) => (
           <li key={document.document_id} className={`document-item status-${document.status}`}>
-            <div>
-              <p className="document-title">{document.title}</p>
-              <p className="document-meta">
-                Utworzono: {new Date(document.created_at).toLocaleString('pl-PL')} • Status: {document.status}
-              </p>
+            <div className="document-info">
+              <div>
+                <p className="document-title">{document.title}</p>
+                <p className="document-meta">
+                  Utworzono: {new Date(document.created_at).toLocaleString('pl-PL')} • Status: {document.status}
+                </p>
+              </div>
+              {document.status === 'ready' && document.token_usage && (
+                <dl className="document-usage">
+                  <div>
+                    <dt>Prompt tokens</dt>
+                    <dd>{formatNumber(document.token_usage.prompt_tokens)}</dd>
+                  </div>
+                  <div>
+                    <dt>Completion tokens</dt>
+                    <dd>{formatNumber(document.token_usage.completion_tokens)}</dd>
+                  </div>
+                  <div>
+                    <dt>Łącznie tokenów</dt>
+                    <dd>{formatNumber(document.token_usage.total_tokens)}</dd>
+                  </div>
+                  <div>
+                    <dt>Koszt</dt>
+                    <dd>{formatCurrency(document.token_usage.cost_usd)}</dd>
+                  </div>
+                </dl>
+              )}
             </div>
             <div className="document-actions">
               <Link to={`/documents/${document.document_id}`}>Otwórz</Link>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -314,6 +314,37 @@ button:not(:disabled):hover,
   font-size: 0.9rem;
 }
 
+.document-usage {
+  margin: 0.5rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.document-usage > div {
+  background-color: #eef2ff;
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.document-usage dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #475569;
+}
+
+.document-usage dd {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+  font-size: 0.95rem;
+}
+
 .document-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- fail fast when the OpenAI chat completion ends before finish_reason=stop and log the normalised payload for easier debugging
- cover truncated OpenAI responses with a regression test
- surface token usage metrics on document cards with supportive styling updates

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1a3824ee48326bca140b8b5f7e2a8