### PR TITLE
Handle truncated OpenAI completions and refresh frontend usage metrics

### DIFF
--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -227,54 +227,106 @@ class OpenAIClient:
         max_tokens: int = 512,
         temperature: float = 0.2,
     ) -> tuple[str, dict[str, int]]:
-        try:
-            logger.debug(
-                "Calling OpenAI chat completion (model=%s, max_tokens=%d, temperature=%.2f)",
-                self._model,
-                max_tokens,
-                temperature,
-            )
-            response = self._client.chat.completions.create(
-                model=self._model,
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-            )
-        except AuthenticationError as exc:  # pragma: no cover - network failure path
-            logger.warning("OpenAI authentication failed: %s", exc)
-            raise OpenAIClientError("Nie udało się uwierzytelnić w OpenAI API.") from exc
-        except Exception as exc:  # pragma: no cover - network failure path
-            logger.exception("OpenAI chat completion failed")
-            raise OpenAIClientError("Nie udało się wywołać OpenAI API.") from exc
-        choices = getattr(response, "choices", None)
-        if not choices:
-            logger.error("OpenAI response did not include choices")
-            raise OpenAIClientError("OpenAI nie zwróciło żadnych wyników.")
-        choice = choices[0]
-        message = getattr(choice, "message", None)
-        content = getattr(message, "content", None)
-        finish_reason = getattr(choice, "finish_reason", None)
-        if finish_reason and finish_reason != "stop":
-            normalised_content = _normalise_json_content(str(content or ""))
-            logger.error(
-                "OpenAI response ended with finish_reason=%s. Raw content: %s\nNormalised content: %s",
-                finish_reason,
-                content,
-                normalised_content,
-            )
-            raise OpenAIClientError(
-                "OpenAI zakończyło generowanie odpowiedzi przedwcześnie."
-            )
-        if not content:
-            logger.error("OpenAI response message missing content")
-            raise OpenAIClientError("Odpowiedź OpenAI nie zawiera treści.")
-        usage_data = getattr(response, "usage", None)
-        usage: dict[str, int] = {
-            "prompt_tokens": int(getattr(usage_data, "prompt_tokens", 0) or 0),
-            "completion_tokens": int(getattr(usage_data, "completion_tokens", 0) or 0),
-            "total_tokens": int(getattr(usage_data, "total_tokens", 0) or 0),
+        aggregated_usage = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
         }
-        return str(content).strip(), usage
+        attempt_max_tokens = max_tokens
+        model_limit = self._model_token_limit()
+
+        for attempt in range(3):
+            try:
+                logger.debug(
+                    "Calling OpenAI chat completion (model=%s, max_tokens=%d, temperature=%.2f, attempt=%d)",
+                    self._model,
+                    attempt_max_tokens,
+                    temperature,
+                    attempt + 1,
+                )
+                response = self._client.chat.completions.create(
+                    model=self._model,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=attempt_max_tokens,
+                )
+            except AuthenticationError as exc:  # pragma: no cover - network failure path
+                logger.warning("OpenAI authentication failed: %s", exc)
+                raise OpenAIClientError("Nie udało się uwierzytelnić w OpenAI API.") from exc
+            except Exception as exc:  # pragma: no cover - network failure path
+                logger.exception("OpenAI chat completion failed")
+                raise OpenAIClientError("Nie udało się wywołać OpenAI API.") from exc
+
+            usage_data = getattr(response, "usage", None)
+            aggregated_usage["prompt_tokens"] += int(
+                getattr(usage_data, "prompt_tokens", 0) or 0
+            )
+            aggregated_usage["completion_tokens"] += int(
+                getattr(usage_data, "completion_tokens", 0) or 0
+            )
+            aggregated_usage["total_tokens"] += int(
+                getattr(usage_data, "total_tokens", 0) or 0
+            )
+
+            choices = getattr(response, "choices", None)
+            if not choices:
+                logger.error("OpenAI response did not include choices")
+                raise OpenAIClientError("OpenAI nie zwróciło żadnych wyników.")
+
+            choice = choices[0]
+            message = getattr(choice, "message", None)
+            content = getattr(message, "content", None)
+            finish_reason = getattr(choice, "finish_reason", None)
+
+            if finish_reason == "length":
+                normalised_content = _normalise_json_content(str(content or ""))
+                logger.warning(
+                    "OpenAI response truncated (finish_reason=length). Raw content: %s\nNormalised content: %s",
+                    content,
+                    normalised_content,
+                )
+                if attempt_max_tokens >= model_limit:
+                    logger.error(
+                        "Reached model token limit (%d) after truncated response.",
+                        model_limit,
+                    )
+                    raise OpenAIClientError(
+                        "OpenAI zakończyło generowanie odpowiedzi przedwcześnie."
+                    )
+                attempt_max_tokens = min(attempt_max_tokens * 2, model_limit)
+                continue
+
+            if finish_reason and finish_reason != "stop":
+                normalised_content = _normalise_json_content(str(content or ""))
+                logger.error(
+                    "OpenAI response ended with finish_reason=%s. Raw content: %s\nNormalised content: %s",
+                    finish_reason,
+                    content,
+                    normalised_content,
+                )
+                raise OpenAIClientError(
+                    "OpenAI zakończyło generowanie odpowiedzi przedwcześnie."
+                )
+
+            if not content:
+                logger.error("OpenAI response message missing content")
+                raise OpenAIClientError("Odpowiedź OpenAI nie zawiera treści.")
+
+            return str(content).strip(), aggregated_usage
+
+        logger.error("Exceeded maximum retry attempts after truncated OpenAI responses")
+        raise OpenAIClientError(
+            "OpenAI zakończyło generowanie odpowiedzi przedwcześnie."
+        )
+
+    def _model_token_limit(self) -> int:
+        model_limits = {
+            "gpt-4o": 128_000,
+            "gpt-4o-mini": 16_384,
+            "gpt-4.1": 128_000,
+            "gpt-4.1-mini": 128_000,
+        }
+        return model_limits.get(self._model, 16_384)
 
     def _complete_json(
         self, messages: list[dict[str, str]], *, max_tokens: int = 512

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import pytest
 
@@ -163,15 +163,69 @@ def test_extract_items_handles_markdown_json_response():
     assert usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
 
-def test_complete_json_raises_on_truncated_response(caplog):
-    response_content = "[\"Niedokonczona odpowiedz"
+def test_complete_json_retries_on_truncated_response(caplog):
+    calls: list[int] = []
 
-    class _LengthCompletions:
-        def create(self, **_: object):
+    class _RetryCompletions:
+        def __init__(self) -> None:
+            self._call_count = 0
+
+        def create(self, **kwargs: object):
+            calls.append(int(kwargs.get("max_tokens", 0)))
+            self._call_count += 1
+            if self._call_count == 1:
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(content='["Niedokonczona odpowiedz"'),
+                            finish_reason="length",
+                        )
+                    ],
+                    usage=SimpleNamespace(
+                        prompt_tokens=10, completion_tokens=20, total_tokens=30
+                    ),
+                )
             return SimpleNamespace(
                 choices=[
                     SimpleNamespace(
-                        message=SimpleNamespace(content=response_content),
+                        message=SimpleNamespace(content='["Gotowe"]'),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=SimpleNamespace(
+                    prompt_tokens=5, completion_tokens=6, total_tokens=11
+                ),
+            )
+
+    client = OpenAIClient(
+        client=SimpleNamespace(chat=SimpleNamespace(completions=_RetryCompletions()))
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result, usage = client._complete_json(
+            [{"role": "user", "content": "Test"}], max_tokens=50
+        )
+
+    assert result == ["Gotowe"]
+    assert usage == {"prompt_tokens": 15, "completion_tokens": 26, "total_tokens": 41}
+    assert calls[0] == 50
+    assert calls[1] >= 100
+    warning_messages = [
+        record.message for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert any("finish_reason=length" in message for message in warning_messages)
+
+
+def test_complete_json_raises_when_truncated_and_limit_reached(caplog):
+    calls: list[int] = []
+
+    class _LengthCompletions:
+        def create(self, **kwargs: object):
+            calls.append(int(kwargs.get("max_tokens", 0)))
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content='["Niedokonczona odpowiedz"'),
                         finish_reason="length",
                     )
                 ],
@@ -181,10 +235,13 @@ def test_complete_json_raises_on_truncated_response(caplog):
     client = OpenAIClient(
         client=SimpleNamespace(chat=SimpleNamespace(completions=_LengthCompletions()))
     )
+    client._model_token_limit = MethodType(lambda self: 64, client)
 
-    with caplog.at_level(logging.ERROR), pytest.raises(OpenAIClientError):
-        client._complete_json([{"role": "user", "content": "Test"}])
+    with caplog.at_level(logging.WARNING), pytest.raises(OpenAIClientError):
+        client._complete_json([{"role": "user", "content": "Test"}], max_tokens=64)
 
+    assert calls == [64]
+    warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
     error_messages = [record.message for record in caplog.records if record.levelno == logging.ERROR]
-    assert any("finish_reason=length" in message for message in error_messages)
-    assert any(response_content in message for message in error_messages)
+    assert any("finish_reason=length" in message for message in warning_messages)
+    assert any("model token limit" in message for message in error_messages)

--- a/frontend/dist/assets/app.js
+++ b/frontend/dist/assets/app.js
@@ -117,6 +117,16 @@ function UploadZone({ onUploadComplete }) {
 }
 
 function DocumentList({ documents, isLoading, onRefresh }) {
+  const formatNumber = (value) =>
+    typeof value === 'number' && Number.isFinite(value)
+      ? value.toLocaleString('pl-PL')
+      : '—';
+
+  const formatCurrency = (value) =>
+    typeof value === 'number' && Number.isFinite(value)
+      ? value.toLocaleString('pl-PL', { style: 'currency', currency: 'USD' })
+      : '—';
+
   return e(
     'section',
     { className: 'panel' },
@@ -146,13 +156,47 @@ function DocumentList({ documents, isLoading, onRefresh }) {
           },
           e(
             'div',
-            null,
-            e('p', { className: 'document-title' }, document.title),
+            { className: 'document-info' },
             e(
-              'p',
-              { className: 'document-meta' },
-              `Utworzono: ${new Date(document.created_at).toLocaleString('pl-PL')} • Status: ${document.status}`
-            )
+              'div',
+              null,
+              e('p', { className: 'document-title' }, document.title),
+              e(
+                'p',
+                { className: 'document-meta' },
+                `Utworzono: ${new Date(document.created_at).toLocaleString('pl-PL')} • Status: ${document.status}`
+              )
+            ),
+            document.status === 'ready' && document.token_usage
+              ? e(
+                  'dl',
+                  { className: 'document-usage' },
+                  e(
+                    'div',
+                    null,
+                    e('dt', null, 'Prompt tokens'),
+                    e('dd', null, formatNumber(document.token_usage.prompt_tokens))
+                  ),
+                  e(
+                    'div',
+                    null,
+                    e('dt', null, 'Completion tokens'),
+                    e('dd', null, formatNumber(document.token_usage.completion_tokens))
+                  ),
+                  e(
+                    'div',
+                    null,
+                    e('dt', null, 'Łącznie tokenów'),
+                    e('dd', null, formatNumber(document.token_usage.total_tokens))
+                  ),
+                  e(
+                    'div',
+                    null,
+                    e('dt', null, 'Koszt'),
+                    e('dd', null, formatCurrency(document.token_usage.cost_usd))
+                  )
+                )
+              : null
           ),
           e(
             'div',


### PR DESCRIPTION
## Summary
- add retry handling for OpenAI responses that end with `finish_reason="length"`, doubling the token budget and aggregating usage
- expose helper for per-model token limits and update tests to cover truncated responses and retry behaviour
- refresh the built frontend assets so document tiles show token and cost information when data is available

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1a787eac08326921fac838f445457