### PR TITLE
Improve OpenAI logging and token sizing

### DIFF
--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -1,6 +1,7 @@
 """Thin wrapper around the official OpenAI client used by the pipeline."""
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from functools import lru_cache
@@ -56,6 +57,45 @@ class OpenAIClient:
         else:
             self._client = client
         self._model = settings.openai_model
+
+    def _summarise_content_for_log(self, content: object) -> str:
+        """Return a privacy-preserving summary of the model output."""
+
+        text = str(content or "").strip()
+        if not text:
+            return "<empty>"
+        normalised = _normalise_json_content(text)
+        collapsed = " ".join(normalised.split())
+        if not collapsed:
+            return "<empty>"
+        digest = hashlib.sha256(collapsed.encode("utf-8")).hexdigest()[:12]
+        return f"{len(collapsed)} chars (sha256={digest})"
+
+    def _estimate_prompt_tokens(self, messages: list[dict[str, str]]) -> int:
+        """Estimate the number of tokens used by the prompt messages."""
+
+        try:  # pragma: no cover - exercised when tiktoken is available
+            import tiktoken
+
+            try:
+                encoding = tiktoken.encoding_for_model(self._model)
+            except KeyError:
+                encoding = tiktoken.get_encoding("cl100k_base")
+
+            total = 0
+            for message in messages:
+                role = message.get("role", "")
+                content = message.get("content", "")
+                total += len(encoding.encode(role))
+                total += len(encoding.encode(content))
+                total += 3  # Per-message framing tokens
+            return total + 3  # Priming tokens
+        except Exception:  # pragma: no cover - deterministic fallback
+            approximate_chars = sum(
+                len(str(message.get("content", ""))) + len(str(message.get("role", "")))
+                for message in messages
+            )
+            return max(1, approximate_chars // 4)
 
     def summarise(self, text: str) -> tuple[str, dict[str, int]]:
         logger.debug("Requesting OpenAI summary (%d chars)", len(text))
@@ -143,7 +183,27 @@ class OpenAIClient:
             },
         ]
         logger.debug("Requesting OpenAI simplification for %d sections", len(payload))
-        data, usage = self._complete_json(messages, max_tokens=1200)
+        prompt_tokens = self._estimate_prompt_tokens(messages)
+        model_limit = self._model_token_limit()
+        safety_margin = 512
+        min_completion = 256
+        raw_budget = max(model_limit - prompt_tokens, 0)
+        if raw_budget <= min_completion:
+            initial_max = max(raw_budget, 1)
+        else:
+            available = max(raw_budget - safety_margin, 0)
+            if available >= min_completion:
+                initial_max = available
+            else:
+                initial_max = raw_budget
+        initial_max = min(int(initial_max), model_limit)
+        logger.debug(
+            "Calculated simplification token budget (prompt=%d, max_tokens=%d, model_limit=%d)",
+            prompt_tokens,
+            initial_max,
+            model_limit,
+        )
+        data, usage = self._complete_json(messages, max_tokens=initial_max)
         if isinstance(data, list):
             logger.debug("Received OpenAI simplification response with %d items", len(data))
         else:
@@ -279,11 +339,11 @@ class OpenAIClient:
             finish_reason = getattr(choice, "finish_reason", None)
 
             if finish_reason == "length":
-                normalised_content = _normalise_json_content(str(content or ""))
                 logger.warning(
-                    "OpenAI response truncated (finish_reason=length). Raw content: %s\nNormalised content: %s",
-                    content,
-                    normalised_content,
+                    "OpenAI response truncated (finish_reason=length, attempt=%d, max_tokens=%d, content_summary=%s)",
+                    attempt + 1,
+                    attempt_max_tokens,
+                    self._summarise_content_for_log(content),
                 )
                 if attempt_max_tokens >= model_limit:
                     logger.error(
@@ -297,12 +357,12 @@ class OpenAIClient:
                 continue
 
             if finish_reason and finish_reason != "stop":
-                normalised_content = _normalise_json_content(str(content or ""))
                 logger.error(
-                    "OpenAI response ended with finish_reason=%s. Raw content: %s\nNormalised content: %s",
+                    "OpenAI response ended with finish_reason=%s (attempt=%d, max_tokens=%d, content_summary=%s)",
                     finish_reason,
-                    content,
-                    normalised_content,
+                    attempt + 1,
+                    attempt_max_tokens,
+                    self._summarise_content_for_log(content),
                 )
                 raise OpenAIClientError(
                     "OpenAI zakończyło generowanie odpowiedzi przedwcześnie."

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ pydantic>=2.7,<3.0
 PyPDF2>=3.0,<4.0
 pydantic-settings>=2.0,<3.0
 openai>=1.0,<2.0
+tiktoken>=0.6,<0.7

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -1,6 +1,7 @@
 """Tests for the OpenAI client helper."""
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -16,6 +17,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from app.core.config import get_settings
+from app.services.ingestion import DocumentSection
 from app.services.openai_client import OpenAIClient, OpenAIClientError
 
 
@@ -214,6 +216,8 @@ def test_complete_json_retries_on_truncated_response(caplog):
         record.message for record in caplog.records if record.levelno == logging.WARNING
     ]
     assert any("finish_reason=length" in message for message in warning_messages)
+    assert all("Niedokonczona" not in message for message in warning_messages)
+    assert any("content_summary" in message for message in warning_messages)
 
 
 def test_complete_json_raises_when_truncated_and_limit_reached(caplog):
@@ -244,4 +248,52 @@ def test_complete_json_raises_when_truncated_and_limit_reached(caplog):
     warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
     error_messages = [record.message for record in caplog.records if record.levelno == logging.ERROR]
     assert any("finish_reason=length" in message for message in warning_messages)
+    assert all("Niedokonczona" not in message for message in warning_messages)
     assert any("model token limit" in message for message in error_messages)
+
+
+def test_simplify_sections_uses_dynamic_token_budget(monkeypatch, caplog):
+    calls: list[int] = []
+
+    class _RecordingCompletions:
+        def create(self, **kwargs: object):
+            calls.append(int(kwargs.get("max_tokens", 0)))
+            response_payload = json.dumps(
+                [
+                    {
+                        "identifier": "section-1",
+                        "plain_language": "Proste streszczenie",
+                        "source_excerpt": "Fragment",
+                    }
+                ],
+                ensure_ascii=False,
+            )
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=response_payload),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=50, completion_tokens=60, total_tokens=110),
+            )
+
+    client = OpenAIClient(client=SimpleNamespace(chat=SimpleNamespace(completions=_RecordingCompletions())))
+    client._model_token_limit = MethodType(lambda self: 4096, client)
+    client._estimate_prompt_tokens = MethodType(lambda self, _: 3000, client)
+
+    with caplog.at_level(logging.WARNING):
+        result, usage = client.simplify_sections(
+            [DocumentSection(identifier="section-1", text="x" * 1000)]
+        )
+
+    assert result == [
+        {
+            "identifier": "section-1",
+            "plain_language": "Proste streszczenie",
+            "source_excerpt": "Fragment",
+        }
+    ]
+    assert usage == {"prompt_tokens": 50, "completion_tokens": 60, "total_tokens": 110}
+    assert calls == [584]
+    assert not any(record.levelno == logging.WARNING for record in caplog.records)


### PR DESCRIPTION
## Summary
- replace raw OpenAI response logging with privacy-preserving summaries and richer metadata
- estimate prompt tokens to size section simplification budgets dynamically and avoid truncation retries
- cover the new behaviours with unit tests and add tiktoken dependency

## Testing
- pytest backend/tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b51912908326b63897f34d90dea1