### PR TITLE
Dokumentacja asynchronicznego pipeline'u

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Monolityczna aplikacja FastAPI z wbudowanym frontendem (React + Vite) obejmuje n
 
 Szczegółowe diagramy i decyzje architektoniczne znajdują się w `docs/architecture.md`.
 
+## Aktualny flow przetwarzania
+
+1. **Upload** – plik trafia do katalogu `/data/{user_id}/{doc_id}/raw` wraz z metadanymi sesji.
+2. **Preprocess** – normalizacja tekstu, OCR i wykrywanie struktury; wersja robocza przechowywana jest w `/data/{user_id}/{doc_id}/preprocessed`.
+3. **Local LLM bootstrap** – inicjalizacja kontekstu użytkownika z pamięci w `/data/llm_store/{user_id}` oraz wczytanie cache modeli.
+4. **Segmentation** – dzielenie na jednostki redakcyjne i tworzenie chunków roboczych (`segments.json`).
+5. **Sanitize** – anonimizacja PII z mapowaniem zapisanym w `/data/{user_id}/{doc_id}/secure/pii_map.json`.
+6. **Parallel OpenAI Simplify** – równoległe upraszczanie segmentów z użyciem funkcji `run_parallel_simplify`, z wynikami tymczasowymi w `/data/{user_id}/{doc_id}/simplified`.
+7. **Validation/Feedback** – kontrola jakości i walidacja reguł (np. długość, kompletność cytatów), z komentarzami użytkownika w `feedback.json`.
+8. **Local LLM update** – aktualizacja pamięci kontekstowej i embeddingów w magazynie per użytkownik (`/data/llm_store/{user_id}`) na podstawie zatwierdzonych segmentów.
+9. **Live Q&A/Export** – wystawienie upraszczonego dokumentu do modułu zapytań i eksportów (PDF/DOCX/Markdown) z artefaktami w `/data/{user_id}/{doc_id}/exports`.
+
 ## Stos technologiczny
 
 - **Backend:** Python 3.12, FastAPI, structlog/loguru, SQLite (MVP) / MariaDB, WeasyPrint.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,44 +1,91 @@
-# Architektura ProstePrawo (MVP)
+# Architektura ProstePrawo (asynchroniczny pipeline)
 
 ## Cel
 
-Monolityczna aplikacja FastAPI z serwowanym statycznie frontendem React ma uprościć cykl przetwarzania aktów prawnych od etapu wgrywania plików, przez anonimizację, indeksację i RAG, po generowanie uproszczonych streszczeń oraz interaktywnych odpowiedzi.
+System przetwarza dokumenty prawne w sposób w pełni asynchroniczny: od wgrywania plików, przez sanitację, uproszczenia i walidację,
+aż po aktualizację kontekstu lokalnego LLM. Celem jest zapewnienie separacji użytkowników, odporności na błędy modeli chmurowych
+oraz możliwości równoległego przetwarzania wielu dokumentów przy kontrolowanym zużyciu zasobów.
 
-## Główne moduły backendu
+## Orkiestracja pipeline'u (`process_document`)
 
-1. **Ingestion** – obsługa uploadów, konwersji PDF/DOCX/obrazów do tekstu, rekonstrukcja struktury (art./§/ust.).
-2. **Sanitizer/PII** – anonimizacja danych wrażliwych (PESEL, NIP, nazwy własne) z wykorzystaniem Presidio i reguł regex.
-3. **Indexing & RAG** – chunkowanie według jednostek redakcyjnych, obliczanie embeddingów (bge-m3/e5-small ONNX), zapis w Elastic lub FAISS.
-4. **Inference** – moduły wywołujące LLM (OpenAI domyślnie, Llama 3.1 lokalnie) do uproszczeń, Q&A i list obowiązków/kar.
-5. **Eksport** – generowanie raportów PDF/DOCX/Markdown, widok „oryginał vs. uproszczony”.
-6. **Audit & Observability** – logowanie zdarzeń zanonimizowanych, wersjonowanie dokumentów, przechowywanie promptów i odpowiedzi.
+Funkcja `process_document` stanowi centralny punkt uruchamiany po uploadzie. Działa w oddzielnym workerze i wykonuje kroki:
 
-## Warstwy implementacji
+1. **Rejestracja zadania** – zapis metadanych dokumentu w bazie i utworzenie folderów `/data/{user_id}/{doc_id}` (podkatalogi
+   `raw`, `preprocessed`, `secure`, `simplified`, `exports`).
+2. **Preprocessing** – normalizacja/OCR, segmentacja struktury (art./§/ust.) i zapis wyników w `preprocessed/segments.json`.
+3. **Sanitacja** – anonimizacja PII z mapą odwzorowań w `secure/pii_map.json`; artefakty jawne są dostępne tylko w kontekście
+   użytkownika.
+4. **Inicjalizacja kontekstu LLM** – odczyt profilu użytkownika i stanu lokalnych modeli z `/data/llm_store/{user_id}`.
+5. **Uruchomienie uproszczeń** – przekazanie zanonimizowanych segmentów do `run_parallel_simplify` wraz z semaforem limitującym
+   zewnętrzne zapytania.
+6. **Walidacja i zapisy** – odbiór wyników z kolejki, walidacja reguł i zapis zatwierdzonych wersji w `simplified/`.
+7. **Aktualizacja pamięci** – synchroniczna aktualizacja embeddingów i kontekstu lokalnego LLM na podstawie zaakceptowanych
+   segmentów.
+8. **Publikacja eventu zakończenia** – wysłanie zdarzenia do kanału progresu (WebSocket/SSE) i przygotowanie eksportów.
 
-- `app/api` – punkty końcowe FastAPI do zarządzania cyklem dokumentów oraz Q&A.
-- `app/services` – usługi dziedzinowe: pipeline, ingest, sanitizer, rag, inference, export.
-- `app/models` – modele Pydantic służące jako kontrakty API i encje domenowe.
-- `app/core` – konfiguracja (Pydantic BaseSettings), inicjalizacja loggera i połączeń.
+`process_document` korzysta z menedżera transakcji/locków tak, aby równoczesne zadania tego samego użytkownika nie kolidowały ze
+sobą, a inni użytkownicy mogli korzystać z klastra niezależnie.
 
-## Przepływ danych (happy path)
+## Równoległe upraszczanie (`run_parallel_simplify`)
 
-1. Użytkownik wgrywa plik → `/documents`.
-2. Pipeline zapisuje plik w `data/{docId}/raw`, tworzy rekord metadanych i rozpoczyna asynchroniczne przetwarzanie.
-3. Ingestion normalizuje tekst, identyfikuje strukturę, wykrywa język i sekcje.
-4. Sanitizer zamienia wrażliwe dane na tagi (<PESEL_1>, <IMIE_2>), zapisuje mapowanie w magazynie `data/{docId}/secure` z uprawnieniami 700/600.
-5. Indeksowanie tworzy wektory + indeks BM25, zapisuje metadane (sygnatura, numer Dz.U., okres obowiązywania) w SQL/Elastic.
-6. Moduł Inference generuje uproszczenia, streszczenia i listy obowiązków/kar, zapisuje cytowane jednostki.
-7. Użytkownik może pobrać eksport (PDF/DOCX/Markdown) lub zadać pytanie Q&A z cytatem.
+Funkcja `run_parallel_simplify` dzieli listę segmentów na porcje dostosowane do ograniczeń tokenów i limitów API. Każdy segment
+jest:
 
-## Tryb „Local-Only”
+- przekazywany do lokalnej kolejki asyncio,
+- wykonywany równolegle do maksymalnej liczby połączeń (`MAX_OPENAI_CONCURRENCY`) chronionej semaforem,
+- buforowany w pamięci podręcznej na poziomie użytkownika (cache promptów/odpowiedzi) w `/data/llm_store/{user_id}/cache.db`.
 
-- Wyłącza wywołania sieciowe modeli (OpenAI), używa lokalnych ONNX/llama.cpp.
-- Wszystkie artefakty pozostają na VPS (folder `data/`).
+W przypadku błędów API zadanie jest ponawiane z jitterem i, po przekroczeniu limitu prób, przekazywane do lokalnego modelu LLM.
+Wyniki są emitowane jako strumień eventów (`SimplifyChunkReady`) pozwalający frontendowi aktualizować UI bez oczekiwania na cały
+pipeline.
 
-## Roadmapa rozszerzeń
+## Walidacja i feedback
 
-1. **MVP**: upload, podstawowe przetwarzanie, mock Q&A (jak w kodzie), podstawowy frontend.
-2. **v0.2**: realny pipeline z OCR, sanitizacją, Elastic + FAISS, generacja streszczeń.
-3. **v0.3**: interaktywny widok „oryginał vs. uproszczony”, definicje, listy obowiązków.
-4. **v0.4**: eksport dokumentów, audyt zdarzeń, logowanie do Elastic.
-5. **v1.0**: pełna obsługa multi-user, SSO, szyfrowanie at-rest, wersjonowanie dokumentów.
+Walidator działa jako kolejny etap asynchroniczny. Dla każdego segmentu sprawdza m.in. kompletność cytatów, zgodność długości,
+redakcję oraz brak wycieków PII. Segmenty, które nie przejdą walidacji, są oznaczane statusem `needs_review` i oczekują na
+feedback użytkownika. UI może przesłać poprawki lub zaakceptować wynik, co wyzwala ponowne uruchomienie uproszczeń dla danej
+porcji. Wszelkie komentarze zapisywane są w `feedback.json`, a historia decyzji trafia do audytu.
+
+## Progresywne eventy i kanały powiadomień
+
+Backend publikuje zdarzenia na kanałach SSE/WebSocket per użytkownik. Główne typy eventów to:
+
+- `DocumentQueued`, `DocumentProcessing`, `DocumentReady` – statusy pipeline'u,
+- `SegmentSimplified` – częściowe wyniki z `run_parallel_simplify`,
+- `ValidationFailed` / `ValidationPassed` – informacja dla UI o koniecznych działaniach,
+- `ExportsUpdated` – powiadomienie o gotowych artefaktach eksportu.
+
+Eventy są wersjonowane i buforowane per użytkownik, aby nowo podłączony klient mógł odtworzyć kontekst.
+
+## Separacja użytkowników i magazyny danych
+
+Każdy użytkownik posiada wydzielone przestrzenie:
+
+- katalog roboczy `/data/{user_id}/{doc_id}` z pełnym cyklem życia dokumentu,
+- magazyn pamięci LLM `/data/llm_store/{user_id}` zawierający historię konwersacji, cache promptów oraz embeddingi,
+- osobne rekordy w bazie (PostgreSQL/MariaDB) z kontrolą uprawnień i audytem.
+
+Dzięki temu pipeline może pracować w trybie multi-tenant przy zachowaniu izolacji danych.
+
+## Cache modeli lokalnych i fallback
+
+Lokalne modele (np. Llama 3.1 8B) są ładowane na żądanie do cache współdzielonego między zadaniami, lecz przestrzenie wektorowe
+są aktualizowane per użytkownik. Menedżer modeli pilnuje, by w pamięci znajdowały się jedynie aktywne modele; pozostałe są
+zapisane na dysku w `models/`. Przy braku odpowiedzi API pipeline korzysta z lokalnej instancji poprzez zunifikowany interfejs,
+co umożliwia seamless fallback.
+
+## Ograniczenia równoległości
+
+- Globalny semafor limituje liczbę równoległych zapytań do dostawcy chmurowego.
+- Per-user semaphore zapobiega nadmiernemu obciążeniu lokalnego cache'u i gwarantuje kolejność aktualizacji pamięci.
+- Zadania walidacji i aktualizacji pamięci są wykonywane w ograniczonej puli workerów CPU, aby uniknąć blokowania event-loopu.
+
+Monitorowanie (Prometheus + structlog) rejestruje wykorzystanie semaforów oraz czasy etapów, co pozwala dynamicznie dostrajać
+parametry.
+
+## Integracja z Q&A i eksportem
+
+Po zatwierdzeniu segmentów `process_document` publikuje finalny snapshot w magazynie RAG (Elastic + FAISS) oraz aktualizuje
+kontekst lokalnego LLM. Moduł Q&A korzysta z tych danych, stosując filtry użytkownika, a eksport (PDF/DOCX/Markdown) generuje
+pliki na podstawie najnowszego stanu katalogu `exports/`. Każdy eksport jest wersjonowany i oznaczony identyfikatorem rewizji
+spójnym z historią walidacji.

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -1,0 +1,25 @@
+# Guidelines wdrożeniowe pipeline'u
+
+## Checklista przygotowania środowiska
+
+- [ ] Utwórz katalog bazowy `/data` z uprawnieniami zapisu dla serwisu.
+- [ ] Zapewnij automatyczne zakładanie struktury `/data/{user_id}/{doc_id}/` (`raw`, `preprocessed`, `secure`, `simplified`, `exports`).
+- [ ] Skonfiguruj per-user store lokalnego LLM w `/data/llm_store/{user_id}` (cache, pamięć konwersacji, embeddingi).
+- [ ] Zweryfikuj dostępność lokalnego repozytorium modeli (`models/`) oraz politykę czyszczenia cache.
+
+## Checklista pipeline'u runtime
+
+- [ ] Włącz globalny semafor limitujący zapytania do OpenAI (`MAX_OPENAI_CONCURRENCY`).
+- [ ] Zaimplementuj per-user semafor/sekwencer zapobiegający kolizjom aktualizacji kontekstu.
+- [ ] Zaimplementuj mapowanie PII i przechowuj je w `secure/pii_map.json` z ograniczonym dostępem.
+- [ ] Rejestrowanie retry i fallbacków do lokalnego modelu dla `run_parallel_simplify`.
+- [ ] Emitowanie progresywnych eventów (`DocumentQueued`, `SegmentSimplified`, `Validation*`, `ExportsUpdated`).
+- [ ] Walidacja segmentów z logiką `needs_review` oraz ścieżką feedbacku użytkownika.
+- [ ] Aktualizacja kontekstu lokalnego LLM po zatwierdzeniu segmentów (embeddingi, pamięć, cache promptów).
+
+## Checklista Q&A i eksportu
+
+- [ ] Publikuj zatwierdzone segmenty do indeksu RAG (Elastic/FAISS) z filtrami per użytkownik.
+- [ ] Zapewnij dostęp modułu Q&A do aktualnego snapshotu kontekstu i historii feedbacku.
+- [ ] Generuj eksporty (PDF/DOCX/Markdown) na podstawie `simplified/` i zapisuj je w `exports/` wraz z metadanymi rewizji.
+- [ ] Wysyłaj event `ExportsUpdated` po każdej zmianie, aby frontend odświeżał listę plików.


### PR DESCRIPTION
## Summary
- opisano w README aktualny flow przetwarzania wraz z artefaktami katalogowymi
- zaktualizowano dokument architektury o szczegóły asynchronicznego pipeline'u i jego ograniczenia
- dodano checklistę wdrożeniową w docs/guidelines.md dla środowiska, pipeline'u i modułów Q&A/Export

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e1bf046f8c83269f8571ec880c33c9