### PR TITLE
Fix legacy document schema migration

### DIFF
--- a/backend/app/repositories/documents.py
+++ b/backend/app/repositories/documents.py
@@ -46,13 +46,21 @@ class DocumentRepository:
             columns = {
                 row["name"] for row in conn.execute("PRAGMA table_info(documents)").fetchall()
             }
-            if "user_id" in columns:
+            if {"user_id", "doc_id", "payload"}.issubset(columns):
                 return
 
-            rows = [
-                {"doc_id": row["doc_id"], "payload": row["payload"]}
-                for row in conn.execute("SELECT doc_id, payload FROM documents").fetchall()
-            ]
+            legacy_rows = conn.execute("SELECT * FROM documents").fetchall()
+            rows = []
+            for row in legacy_rows:
+                row_dict = dict(row)
+                payload_data = json.loads(row_dict["payload"])
+
+                doc_id = row_dict.get("doc_id") or row_dict.get("id") or payload_data.get("doc_id")
+                if doc_id is None:
+                    raise sqlite3.OperationalError("Unable to determine document identifier during migration")
+
+                payload_data["doc_id"] = str(doc_id)
+                rows.append({"doc_id": str(doc_id), "payload": json.dumps(payload_data)})
 
             conn.execute("DROP TABLE documents")
             conn.execute(_CREATE_TABLE_SQL)


### PR DESCRIPTION
## Summary
- handle legacy document tables that lack the new composite key columns by reading all available fields
- ensure migrated payloads always include doc identifiers before recreating the documents table

## Testing
- `PYTHONPATH=. pytest tests/test_document_repository.py`


------
https://chatgpt.com/codex/tasks/task_e_68e6e266a67883269244e0c4826ddb62