### PR TITLE
Ensure demo session bootstrap and include credentials in frontend requests

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,12 +1,12 @@
 """Reusable FastAPI dependency helpers for authentication."""
 from __future__ import annotations
 
-from fastapi import Cookie, Depends, HTTPException, status
+from fastapi import Cookie, Depends, HTTPException, Response, status
 
 from ..core.config import Settings, get_settings
 from ..models.auth import User
 from ..repositories.users import UserRepository
-from ..services.session_manager import SESSION_COOKIE_NAME, SessionManager
+from ..services.session_manager import SESSION_COOKIE_NAME, SESSION_MAX_AGE, SessionManager
 
 
 def get_user_repository() -> UserRepository:
@@ -21,21 +21,48 @@ def _session_manager(settings: Settings) -> SessionManager:
 
 
 async def get_current_user(
+    response: Response,
     session_token: str | None = Cookie(default=None, alias=SESSION_COOKIE_NAME),
     settings: Settings = Depends(get_settings),
     repository: UserRepository = Depends(get_user_repository),
 ) -> User:
     """Return the authenticated user based on the session cookie."""
 
-    if not session_token:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Brak aktywnej sesji.")
-
     manager = _session_manager(settings)
+    fallback_allowed = settings.environment != "production"
+
+    def _bootstrap_demo_session() -> User:
+        if not fallback_allowed:
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Brak aktywnej sesji.")
+        user = repository.ensure_demo_user()
+        token = manager.create(user.id)
+        _set_session_cookie(response, token, settings)
+        return user
+
+    if not session_token:
+        return _bootstrap_demo_session()
+
     user_id = manager.verify(session_token)
     if user_id is None:
+        if fallback_allowed:
+            return _bootstrap_demo_session()
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Sesja wygasła lub jest nieprawidłowa.")
 
     try:
         return repository.get_user_by_id(user_id)
-    except KeyError as exc:  # pragma: no cover - extremely rare edge case
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Sesja wygasła lub jest nieprawidłowa.") from exc
+    except KeyError:
+        if fallback_allowed:
+            return _bootstrap_demo_session()
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Sesja wygasła lub jest nieprawidłowa.")
+
+
+def _set_session_cookie(response: Response, token: str, settings: Settings) -> None:
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        secure=settings.environment == "production",
+        samesite="lax",
+        max_age=SESSION_MAX_AGE,
+        path="/",
+    )

--- a/backend/app/repositories/users.py
+++ b/backend/app/repositories/users.py
@@ -12,6 +12,8 @@ from ..models.auth import PasswordResetToken, User, VerificationToken
 
 
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+DEMO_USER_EMAIL = "demo@prosteprawo.local"
+DEMO_USER_PASSWORD_HASH = "$2b$12$C6UzMDM.H6dfI/f/IKGheu"
 
 
 class UserRepository:
@@ -127,6 +129,19 @@ class UserRepository:
             rows = conn.execute("SELECT * FROM users ORDER BY created_at").fetchall()
         for row in rows:
             yield _row_to_user(row)
+
+    def ensure_demo_user(self) -> User:
+        """Return a demo user, creating it when missing.
+
+        In development environments we automatically provision a placeholder
+        account to simplify manual testing without going through the
+        registration flow.
+        """
+
+        user = self.get_user_by_email(DEMO_USER_EMAIL)
+        if user is not None:
+            return user
+        return self.create_user(DEMO_USER_EMAIL, DEMO_USER_PASSWORD_HASH, is_verified=True)
 
     # ------------------------------------------------------------------
     # Verification tokens
@@ -257,3 +272,4 @@ def _parse_datetime(value: str) -> datetime:
     if not value:
         raise ValueError("Empty datetime value")
     return datetime.strptime(value, ISO_FORMAT)
+

--- a/frontend/src/components/QaModal.tsx
+++ b/frontend/src/components/QaModal.tsx
@@ -43,7 +43,9 @@ function QaModal({ documentId, onClose, onHighlightSource }: QaModalProps) {
     setAnswer(null);
     try {
       const params = new URLSearchParams({ question });
-      const response = await fetch(`${API_BASE_URL}/documents/${documentId}/qa?${params.toString()}`);
+      const response = await fetch(`${API_BASE_URL}/documents/${documentId}/qa?${params.toString()}`, {
+        credentials: 'include'
+      });
       if (!response.ok) {
         throw new Error('Nie udało się pobrać odpowiedzi.');
       }

--- a/frontend/src/components/UploadZone.tsx
+++ b/frontend/src/components/UploadZone.tsx
@@ -26,7 +26,8 @@ function UploadZone({ onUploadComplete }: UploadZoneProps) {
       try {
         const response = await fetch(`${API_BASE_URL}/documents/`, {
           method: 'POST',
-          body: formData
+          body: formData,
+          credentials: 'include'
         });
         if (!response.ok) {
           const message = await response.text();

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -11,7 +11,9 @@ function DashboardPage() {
   const loadDocuments = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await fetch(`${API_BASE_URL}/documents/`);
+      const response = await fetch(`${API_BASE_URL}/documents/`, {
+        credentials: 'include'
+      });
       if (!response.ok) {
         throw new Error('Nie udało się pobrać dokumentów.');
       }

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -31,7 +31,9 @@ function ExportPage() {
     setError(null);
     try {
       const params = new URLSearchParams({ format, restore_pii: restorePii ? 'true' : 'false' });
-      const response = await fetch(`${API_BASE_URL}/documents/${documentId}/export?${params.toString()}`);
+      const response = await fetch(`${API_BASE_URL}/documents/${documentId}/export?${params.toString()}`, {
+        credentials: 'include'
+      });
       if (!response.ok) {
         const details = await response.text();
         throw new Error(details || 'Nie udało się wygenerować eksportu.');

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -30,8 +30,8 @@ function ReaderPage() {
       setError(null);
       try {
         const [metaResponse, simplifiedResponse] = await Promise.all([
-          fetch(`${API_BASE_URL}/documents/${documentId}`),
-          fetch(`${API_BASE_URL}/documents/${documentId}/simplified`)
+          fetch(`${API_BASE_URL}/documents/${documentId}`, { credentials: 'include' }),
+          fetch(`${API_BASE_URL}/documents/${documentId}/simplified`, { credentials: 'include' })
         ]);
         if (metaResponse.status === 404) {
           setError('Nie znaleziono dokumentu.');


### PR DESCRIPTION
## Summary
- automatically create and persist a demo user/session cookie in development when no valid session is present
- expose a repository helper for provisioning the demo account
- include credentials with all frontend document API requests to carry the session cookie

## Testing
- pytest
- npm install *(fails: npm registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e6f27813608326b23f569e222d55a8