### PR TITLE
Handle documents requiring manual review

### DIFF
--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -57,6 +57,7 @@ class DocumentProcessingStatus(str, Enum):
 
     RECEIVED = "received"
     PROCESSING = "processing"
+    NEEDS_REVIEW = "needs_review"
     READY = "ready"
     FAILED = "failed"
 

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -247,7 +247,7 @@ class DocumentPipeline:
             metadata.extra["validation"] = validation
             if validation["issues"]:
                 metadata.extra["needs_review"] = validation["issues"]
-                metadata.status = DocumentProcessingStatus.PROCESSING
+                metadata.status = DocumentProcessingStatus.NEEDS_REVIEW
                 await self._emit_event(
                     "ValidationFailed",
                     metadata,
@@ -430,7 +430,10 @@ class DocumentPipeline:
 
     def get_simplified_sections(self, user_id: int, doc_id: UUID) -> list[SectionSimplification]:
         metadata = self._get(user_id, doc_id)
-        if metadata.status != DocumentProcessingStatus.READY:
+        if metadata.status not in (
+            DocumentProcessingStatus.READY,
+            DocumentProcessingStatus.NEEDS_REVIEW,
+        ):
             raise DocumentNotReadyError(user_id, doc_id)
         return list(metadata.simplified_sections)
 

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -1,5 +1,13 @@
 import { Link } from 'react-router-dom';
-import type { DocumentListItem } from '../types';
+import type { DocumentListItem, DocumentStatus } from '../types';
+
+const statusLabels: Record<DocumentStatus, string> = {
+  received: 'odebrany',
+  processing: 'przetwarzanie',
+  needs_review: 'wymaga weryfikacji',
+  ready: 'gotowy',
+  failed: 'błąd'
+};
 
 interface DocumentListProps {
   documents: DocumentListItem[];
@@ -29,41 +37,52 @@ function DocumentList({ documents, isLoading, onRefresh }: DocumentListProps) {
       {isLoading && <p>Wczytywanie listy dokumentów...</p>}
       {!isLoading && documents.length === 0 && <p>Brak dokumentów. Prześlij plik aby rozpocząć analizę.</p>}
       <ul className="document-list">
-        {documents.map((document) => (
-          <li key={document.doc_id} className={`document-item status-${document.status}`}>
-            <div className="document-info">
-              <div>
-                <p className="document-title">{document.title}</p>
-                <p className="document-meta">
-                  Utworzono: {new Date(document.created_at).toLocaleString('pl-PL')} • Status: {document.status}
-                </p>
+        {documents.map((document) => {
+          const needsReviewIssues = Array.isArray(document.extra?.needs_review)
+            ? (document.extra?.needs_review as unknown[])
+            : null;
+
+          return (
+            <li key={document.doc_id} className={`document-item status-${document.status}`}>
+              <div className="document-info">
+                <div>
+                  <p className="document-title">{document.title}</p>
+                  <p className="document-meta">
+                    Utworzono: {new Date(document.created_at).toLocaleString('pl-PL')} • Status: {statusLabels[document.status]}
+                  </p>
+                  {document.status === 'needs_review' && needsReviewIssues && (
+                    <p className="status-message">
+                      Dokument wymaga ręcznej weryfikacji {needsReviewIssues.length > 1 ? 'segmentów' : 'segmentu'}.
+                    </p>
+                  )}
+                </div>
+                {document.status === 'ready' && document.token_usage && (
+                  <dl className="document-usage">
+                    <div>
+                      <dt>Prompt tokens</dt>
+                      <dd>{formatNumber(document.token_usage.prompt_tokens)}</dd>
+                    </div>
+                    <div>
+                      <dt>Completion tokens</dt>
+                      <dd>{formatNumber(document.token_usage.completion_tokens)}</dd>
+                    </div>
+                    <div>
+                      <dt>Łącznie tokenów</dt>
+                      <dd>{formatNumber(document.token_usage.total_tokens)}</dd>
+                    </div>
+                    <div>
+                      <dt>Koszt</dt>
+                      <dd>{formatCurrency(document.token_usage.cost_usd)}</dd>
+                    </div>
+                  </dl>
+                )}
               </div>
-              {document.status === 'ready' && document.token_usage && (
-                <dl className="document-usage">
-                  <div>
-                    <dt>Prompt tokens</dt>
-                    <dd>{formatNumber(document.token_usage.prompt_tokens)}</dd>
-                  </div>
-                  <div>
-                    <dt>Completion tokens</dt>
-                    <dd>{formatNumber(document.token_usage.completion_tokens)}</dd>
-                  </div>
-                  <div>
-                    <dt>Łącznie tokenów</dt>
-                    <dd>{formatNumber(document.token_usage.total_tokens)}</dd>
-                  </div>
-                  <div>
-                    <dt>Koszt</dt>
-                    <dd>{formatCurrency(document.token_usage.cost_usd)}</dd>
-                  </div>
-                </dl>
-              )}
-            </div>
-            <div className="document-actions">
-              <Link to={`/documents/${document.doc_id}`}>Otwórz</Link>
-            </div>
-          </li>
-        ))}
+              <div className="document-actions">
+                <Link to={`/documents/${document.doc_id}`}>Otwórz</Link>
+              </div>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -6,9 +6,18 @@ import QaModal from '../components/QaModal';
 import CostOverviewPanel from '../components/CostOverviewPanel';
 import type {
   DocumentMetadataPublic,
+  DocumentStatus,
   SectionSimplification,
   SimplifiedResponse
 } from '../types';
+
+const statusLabels: Record<DocumentStatus, string> = {
+  received: 'odebrany',
+  processing: 'przetwarzanie',
+  needs_review: 'wymaga weryfikacji',
+  ready: 'gotowy',
+  failed: 'błąd'
+};
 
 function ReaderPage() {
   const { documentId } = useParams();
@@ -64,6 +73,7 @@ function ReaderPage() {
   }, [activeSection]);
 
   const ready = metadata?.status === 'ready';
+  const reviewable = metadata?.status === 'ready' || metadata?.status === 'needs_review';
 
   const insights = useMemo(() => {
     if (!metadata) {
@@ -89,7 +99,12 @@ function ReaderPage() {
             ← Wróć
           </button>
           <h1>{metadata?.title ?? 'Dokument'}</h1>
-          <p>Status: {metadata?.status ?? 'ładowanie...'}</p>
+          <p>Status: {metadata ? statusLabels[metadata.status] : 'ładowanie...'}</p>
+          {metadata?.status === 'needs_review' && (
+            <p className="status-message">
+              Wykryto potencjalne problemy wymagające weryfikacji. Zapoznaj się z uproszczeniami i potwierdź poprawność.
+            </p>
+          )}
         </div>
         <div className="reader-tools">
           <label>
@@ -106,7 +121,7 @@ function ReaderPage() {
       </header>
       {isLoading && <p>Ładowanie dokumentu...</p>}
       {error && <p className="error-message">{error}</p>}
-      {!isLoading && !error && (
+      {!isLoading && !error && reviewable && (
         <>
           <SectionViewer
             sections={sections}
@@ -133,6 +148,11 @@ function ReaderPage() {
             ))}
           </aside>
         </>
+      )}
+      {!isLoading && !error && !reviewable && (
+        <p className="status-message">
+          Dokument jest nadal w trakcie przetwarzania. Spróbuj ponownie później.
+        </p>
       )}
       {showQa && (
         <QaModal

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -373,6 +373,11 @@ button:not(:disabled):hover,
   color: #c2410c;
 }
 
+.status-needs_review {
+  background-color: rgba(14, 165, 233, 0.15);
+  color: #0369a1;
+}
+
 .status-received {
   background-color: rgba(59, 130, 246, 0.15);
   color: #1d4ed8;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,9 @@
-export type DocumentStatus = 'received' | 'processing' | 'ready' | 'failed';
+export type DocumentStatus =
+  | 'received'
+  | 'processing'
+  | 'needs_review'
+  | 'ready'
+  | 'failed';
 
 export interface SectionSimplification {
   identifier: string;
@@ -27,6 +32,7 @@ export interface DocumentMetadataPublic {
   risks: string[];
   simplified_sections: SectionSimplification[];
   token_usage: TokenUsageMetrics;
+  extra?: Record<string, any>;
 }
 
 export interface DocumentListItem extends DocumentMetadataPublic {}


### PR DESCRIPTION
## Summary
- add a dedicated `needs_review` processing status for documents that fail automated validation
- allow simplified document sections to be retrieved while awaiting manual review and persist the status in metadata
- update the dashboard and reader UI to surface the new status with contextual messaging and styling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e6f69df7d88326a381d926ed585d09