### PR TITLE
Improve document processing progress feedback and concurrency

### DIFF
--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -7,7 +7,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 from uuid import UUID
 
 from fastapi import UploadFile
@@ -108,6 +108,7 @@ class DocumentPipeline:
             metadata.status = DocumentProcessingStatus.PROCESSING
             self.repository.upsert(metadata)
             await self._emit_event("ProcessingStarted", metadata, title=metadata.title)
+            self._update_progress(metadata, 5.0)
 
             self._llm_store.bootstrap(user_id)
 
@@ -128,6 +129,7 @@ class DocumentPipeline:
                 encoding="utf-8",
             )
             await self._emit_event("SegmentsGenerated", metadata, count=len(segments))
+            self._update_progress(metadata, 15.0)
 
             sanitized_segments, entities, secrets = sanitizer.sanitize_segments(segments)
             sanitized_dir = base_dir / "sanitized"
@@ -163,6 +165,7 @@ class DocumentPipeline:
             metadata.sanitized_path = sanitized_document_path
             metadata.pii_placeholders = entities
             metadata.pii_secret_path = pii_path
+            self._update_progress(metadata, 25.0)
 
             sanitized_sections = [
                 ingestion.DocumentSection(identifier=segment.identifier, text=segment.text)
@@ -177,51 +180,96 @@ class DocumentPipeline:
                 flat_vectors.extend(segment.embedding)
             self._llm_store.store_vectors(user_id, flat_vectors)
             await self._emit_event("IndexUpdated", metadata, sections=len(sanitized_sections))
+            self._update_progress(metadata, 35.0)
 
             use_cloud = self._settings.enable_cloud_llm
             usage_totals = DocumentUsageMetrics()
 
-            summary, summary_usage = await asyncio.to_thread(
-                inference.build_summary, sanitized_text, use_cloud
-            )
+            analysis_tasks = {
+                asyncio.create_task(
+                    asyncio.to_thread(inference.build_summary, sanitized_text, use_cloud)
+                ): "summary",
+                asyncio.create_task(
+                    asyncio.to_thread(
+                        inference.extract_obligations, sanitized_text, use_cloud
+                    )
+                ): "obligations",
+                asyncio.create_task(
+                    asyncio.to_thread(
+                        inference.extract_penalties, sanitized_text, use_cloud
+                    )
+                ): "penalties",
+                asyncio.create_task(
+                    asyncio.to_thread(
+                        inference.extract_deadlines, sanitized_text, use_cloud
+                    )
+                ): "deadlines",
+                asyncio.create_task(
+                    asyncio.to_thread(inference.extract_risks, sanitized_text, use_cloud)
+                ): "risks",
+            }
+
+            analysis_results: dict[str, tuple[Any, DocumentUsageMetrics]] = {}
+            total_analysis = len(analysis_tasks) or 1
+            completed_analysis = 0
+            analysis_start = 35.0
+            analysis_end = 55.0
+            analysis_range = analysis_end - analysis_start
+
+            for finished in asyncio.as_completed(analysis_tasks):
+                name = analysis_tasks[finished]
+                result = await finished
+                analysis_results[name] = result
+                completed_analysis += 1
+                progress_value = analysis_start + (completed_analysis / total_analysis) * analysis_range
+                self._update_progress(metadata, progress_value)
+
+            summary, summary_usage = analysis_results.get("summary", ("", DocumentUsageMetrics()))
             metadata.summary = summary
             usage_totals.accumulate(summary_usage)
 
-            obligations, obligations_usage = await asyncio.to_thread(
-                inference.extract_obligations, sanitized_text, use_cloud
+            obligations, obligations_usage = analysis_results.get(
+                "obligations", ([], DocumentUsageMetrics())
             )
             metadata.obligations = obligations
             usage_totals.accumulate(obligations_usage)
 
-            penalties, penalties_usage = await asyncio.to_thread(
-                inference.extract_penalties, sanitized_text, use_cloud
+            penalties, penalties_usage = analysis_results.get(
+                "penalties", ([], DocumentUsageMetrics())
             )
             metadata.penalties = penalties
             usage_totals.accumulate(penalties_usage)
 
-            deadlines, deadlines_usage = await asyncio.to_thread(
-                inference.extract_deadlines, sanitized_text, use_cloud
+            deadlines, deadlines_usage = analysis_results.get(
+                "deadlines", ([], DocumentUsageMetrics())
             )
             metadata.deadlines = deadlines
             usage_totals.accumulate(deadlines_usage)
 
-            risks, risks_usage = await asyncio.to_thread(
-                inference.extract_risks, sanitized_text, use_cloud
-            )
+            risks, risks_usage = analysis_results.get("risks", ([], DocumentUsageMetrics()))
             metadata.risks = risks
             usage_totals.accumulate(risks_usage)
 
+            simplify_start = 55.0
+            simplify_end = 80.0
+
+            def _on_simplify_progress(ratio: float) -> None:
+                target = simplify_start + max(0.0, min(1.0, ratio)) * (simplify_end - simplify_start)
+                self._update_progress(metadata, target)
+
             simplifications, simplify_usage = await self._run_parallel_simplify(
-                metadata, sanitized_sections, use_cloud
+                metadata, sanitized_sections, use_cloud, progress_callback=_on_simplify_progress
             )
             metadata.simplified_sections = simplifications
             usage_totals.accumulate(simplify_usage)
             await self._emit_event("SimplificationCompleted", metadata, sections=len(simplifications))
+            self._update_progress(metadata, simplify_end)
 
             definitions = await asyncio.to_thread(
                 inference.extract_definitions, sanitized_text
             )
             metadata.definitions = definitions
+            self._update_progress(metadata, 90.0)
 
             if usage_totals.total_tokens == 0 and (
                 usage_totals.prompt_tokens or usage_totals.completion_tokens
@@ -260,12 +308,14 @@ class DocumentPipeline:
 
             self._llm_store.update_context(user_id, "validation", validation)
             self.repository.upsert(metadata)
+            self._update_progress(metadata, 100.0)
             await self._emit_event("ProcessingCompleted", metadata, status=metadata.status.value)
         except Exception as exc:  # pragma: no cover - defensive path
             logger.exception("Processing workflow for %s/%s failed: %s", user_id, doc_id, exc)
             metadata.status = DocumentProcessingStatus.FAILED
             metadata.extra["error"] = str(exc)
             self.repository.upsert(metadata)
+            self._update_progress(metadata, 100.0)
             await self._emit_event("ProcessingFailed", metadata, error=str(exc))
 
     async def _run_parallel_simplify(
@@ -273,6 +323,7 @@ class DocumentPipeline:
         metadata: DocumentMetadata,
         sections: list[ingestion.DocumentSection],
         use_cloud: bool,
+        progress_callback: Callable[[float], None] | None = None,
     ) -> tuple[list[SectionSimplification], DocumentUsageMetrics]:
         semaphore = self._semaphores.setdefault(
             metadata.user_id, asyncio.Semaphore(self.MAX_OPENAI_CONCURRENCY)
@@ -302,12 +353,20 @@ class DocumentPipeline:
             return result, usage
 
         tasks = [asyncio.create_task(_simplify_chunk(chunk)) for chunk in chunks]
-        results = await asyncio.gather(*tasks)
+        total_chunks = len(tasks) or 1
+        completed_chunks = 0
         simplifications: list[SectionSimplification] = []
         total_usage = DocumentUsageMetrics()
-        for chunk_result, usage in results:
+        for future in asyncio.as_completed(tasks):
+            chunk_result, usage = await future
             simplifications.extend(chunk_result)
             total_usage.accumulate(usage)
+            completed_chunks += 1
+            if progress_callback is not None:
+                ratio = completed_chunks / total_chunks
+                progress_callback(ratio)
+        if not tasks and progress_callback is not None:
+            progress_callback(1.0)
         return simplifications, total_usage
 
     async def _validate_document(
@@ -494,6 +553,17 @@ class DocumentPipeline:
             return self.repository.get(user_id, doc_id)
         except KeyError as exc:
             raise DocumentNotFoundError(user_id, doc_id) from exc
+
+    def _update_progress(self, metadata: DocumentMetadata, value: float) -> None:
+        try:
+            current = float(metadata.extra.get("progress", 0.0))
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            current = 0.0
+        clamped = max(0.0, min(100.0, float(value)))
+        if clamped <= current:
+            return
+        metadata.extra["progress"] = round(clamped, 2)
+        self.repository.upsert(metadata)
 
 
 def _contains_pii(text: str) -> bool:

--- a/backend/tests/test_pipeline_async.py
+++ b/backend/tests/test_pipeline_async.py
@@ -40,7 +40,12 @@ async def test_run_parallel_simplify_honours_semaphore():
     metadata = DocumentMetadata(user_id=1, title="Test")
 
     with patch.object(inference, "simplify_sections", side_effect=fake_simplify):
-        simplifications, _ = await pipeline._run_parallel_simplify(metadata, sections, use_cloud=False)
+        simplifications, _ = await pipeline._run_parallel_simplify(
+            metadata,
+            sections,
+            use_cloud=False,
+            progress_callback=lambda _ratio: None,
+        )
 
     assert len(simplifications) == len(sections)
     assert observed <= pipeline.MAX_OPENAI_CONCURRENCY

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -41,6 +41,11 @@ function DocumentList({ documents, isLoading, onRefresh }: DocumentListProps) {
           const needsReviewIssues = Array.isArray(document.extra?.needs_review)
             ? (document.extra?.needs_review as unknown[])
             : null;
+          const rawProgress = document.extra?.progress;
+          const progress =
+            typeof rawProgress === 'number' && Number.isFinite(rawProgress)
+              ? Math.min(100, Math.max(0, Math.round(rawProgress)))
+              : null;
 
           return (
             <li key={document.doc_id} className={`document-item status-${document.status}`}>
@@ -50,6 +55,14 @@ function DocumentList({ documents, isLoading, onRefresh }: DocumentListProps) {
                   <p className="document-meta">
                     Utworzono: {new Date(document.created_at).toLocaleString('pl-PL')} • Status: {statusLabels[document.status]}
                   </p>
+                  {document.status === 'processing' && progress !== null && (
+                    <div className="document-progress">
+                      <div className="progress-bar" aria-hidden="true">
+                        <div className="progress-bar-fill" style={{ width: `${progress}%` }} />
+                      </div>
+                      <p className="progress-label">Postęp przetwarzania: {progress}%</p>
+                    </div>
+                  )}
                   {document.status === 'needs_review' && needsReviewIssues && (
                     <p className="status-message">
                       Dokument wymaga ręcznej weryfikacji {needsReviewIssues.length > 1 ? 'segmentów' : 'segmentu'}.

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -314,6 +314,34 @@ button:not(:disabled):hover,
   font-size: 0.9rem;
 }
 
+.document-progress {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.progress-bar {
+  width: 220px;
+  max-width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.16);
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #2563eb, #38bdf8);
+  transition: width 0.3s ease;
+}
+
+.progress-label {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #1e293b;
+}
+
 .document-usage {
   margin: 0.5rem 0 0;
   display: grid;


### PR DESCRIPTION
## Summary
- add progress tracking throughout the document processing pipeline and expose it in stored metadata
- execute OpenAI-powered analysis steps in parallel while keeping simplification updates incremental
- surface a visual progress indicator in the dashboard document list to show processing percentage

## Testing
- pytest backend/tests/test_pipeline_async.py

------
https://chatgpt.com/codex/tasks/task_e_68e6f9fcd9608326930eef1096a008f3