### PR TITLE
Fix analysis result accumulation in document pipeline

### DIFF
--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -230,7 +230,25 @@ class DocumentPipeline:
                     name = analysis_tasks.pop(finished, None)
                     if name is None:
                         continue
-                    analysis_results[name] = await finished
+                    finished_name, finished_result = await finished
+                    if finished_name != name:
+                        logger.debug(
+                            "Analysis task name mismatch: expected %%s, got %%s",
+                            name,
+                            finished_name,
+                        )
+                    if (
+                        not isinstance(finished_result, tuple)
+                        or len(finished_result) != 2
+                        or not isinstance(finished_result[1], DocumentUsageMetrics)
+                    ):
+                        logger.error(
+                            "Unexpected analysis result structure for %s: %r",
+                            name,
+                            finished_result,
+                        )
+                        continue
+                    analysis_results[name] = finished_result
                 completed_analysis += 1
                 progress_value = analysis_start + (completed_analysis / total_analysis) * analysis_range
                 self._update_progress(metadata, progress_value)


### PR DESCRIPTION
## Summary
- ensure analysis task results only store inference outputs before accumulating usage metrics
- add logging guard for unexpected task result structures to prevent pipeline crashes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6ffb974548326b765aeaed2f34545