### PR TITLE
Prevent OpenAI calls on empty document payloads

### DIFF
--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -53,8 +53,15 @@ def _build_summary_local(text: str) -> str:
     return first
 
 
+def _has_meaningful_text(text: str) -> bool:
+    return bool(text and text.strip())
+
+
 def build_summary(text: str, use_cloud: bool | None = None) -> tuple[str, DocumentUsageMetrics]:
     """Return a short summary, preferring OpenAI when available."""
+
+    if not _has_meaningful_text(text):
+        return _build_summary_local(text), _zero_usage()
 
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
@@ -80,6 +87,9 @@ def _collect_sentences(text: str, keywords: Iterable[str]) -> list[str]:
 
 
 def extract_obligations(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
+    if not _has_meaningful_text(text):
+        return [], _zero_usage()
+
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
@@ -92,6 +102,9 @@ def extract_obligations(text: str, use_cloud: bool | None = None) -> tuple[list[
 
 
 def extract_penalties(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
+    if not _has_meaningful_text(text):
+        return [], _zero_usage()
+
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
@@ -104,6 +117,9 @@ def extract_penalties(text: str, use_cloud: bool | None = None) -> tuple[list[st
 
 
 def extract_deadlines(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
+    if not _has_meaningful_text(text):
+        return [], _zero_usage()
+
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
@@ -116,6 +132,9 @@ def extract_deadlines(text: str, use_cloud: bool | None = None) -> tuple[list[st
 
 
 def extract_risks(text: str, use_cloud: bool | None = None) -> tuple[list[str], DocumentUsageMetrics]:
+    if not _has_meaningful_text(text):
+        return [], _zero_usage()
+
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:
@@ -188,6 +207,8 @@ def simplify_sections(
     """Generate plain-language explanations using OpenAI when enabled."""
 
     section_list = list(sections)
+    if not any(_has_meaningful_text(section.text) for section in section_list):
+        return [], _zero_usage()
     if _should_use_cloud(use_cloud):
         client = get_openai_client()
         try:

--- a/backend/tests/test_inference.py
+++ b/backend/tests/test_inference.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.services import inference
+from app.services.ingestion import DocumentSection
+
+
+def test_build_summary_skips_cloud_when_text_blank(monkeypatch):
+    monkeypatch.setattr(inference, "_should_use_cloud", lambda use_cloud: True)
+
+    def _fail():  # pragma: no cover - defensive guard
+        raise AssertionError("get_openai_client should not be called")
+
+    monkeypatch.setattr(inference, "get_openai_client", _fail)
+
+    summary, usage = inference.build_summary("   ")
+
+    assert summary == "Brak treści do podsumowania."
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+
+
+def test_extract_penalties_skips_cloud_when_text_blank(monkeypatch):
+    monkeypatch.setattr(inference, "_should_use_cloud", lambda use_cloud: True)
+
+    def _fail():  # pragma: no cover - defensive guard
+        raise AssertionError("get_openai_client should not be called")
+
+    monkeypatch.setattr(inference, "get_openai_client", _fail)
+
+    penalties, usage = inference.extract_penalties("\n\t")
+
+    assert penalties == []
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+
+
+def test_simplify_sections_skips_cloud_when_all_text_blank(monkeypatch):
+    monkeypatch.setattr(inference, "_should_use_cloud", lambda use_cloud: True)
+
+    def _fail():  # pragma: no cover - defensive guard
+        raise AssertionError("get_openai_client should not be called")
+
+    monkeypatch.setattr(inference, "get_openai_client", _fail)
+
+    result, usage = inference.simplify_sections(
+        [DocumentSection(identifier="1", text="   ")]
+    )
+
+    assert result == []
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0


### PR DESCRIPTION
## Summary
- avoid invoking the OpenAI client when summaries or extractions receive empty document text and fall back to local heuristics
- short-circuit section simplification when all sections are blank to skip unnecessary cloud calls
- add regression tests that enforce the new guard clauses for blank text inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e8363a9a3c8326a9441ec8780a5530