### PR TITLE
Add template generation endpoint for Polish legal documents

### DIFF
--- a/backend/app/api/routes/templates.py
+++ b/backend/app/api/routes/templates.py
@@ -1,0 +1,34 @@
+"""Endpoints for generating legal document templates."""
+from fastapi import APIRouter, Depends, HTTPException
+
+from ...api.deps import get_current_user
+from ...models.auth import User
+from ...models.templates import TemplateGenerationRequest, TemplateGenerationResponse
+from ...services import inference
+
+router = APIRouter()
+
+
+@router.post(
+    "/",
+    summary="Generate a legal document template",
+    response_model=TemplateGenerationResponse,
+)
+async def create_template(
+    payload: TemplateGenerationRequest,
+    current_user: User = Depends(get_current_user),
+) -> TemplateGenerationResponse:
+    """Produce a structured template tailored to the selected country."""
+
+    try:
+        template, usage = inference.generate_document_template(payload.prompt, payload.country)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return TemplateGenerationResponse(
+        user_id=current_user.id,
+        country=payload.country.strip().upper() or "PL",
+        prompt=payload.prompt.strip(),
+        template=template,
+        token_usage=usage,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from .api.routes import auth, documents, health
+from .api.routes import auth, documents, health, templates
 
 
 BASE_DIR = _discover_project_root()
@@ -56,6 +56,7 @@ api_router = APIRouter(prefix="/api")
 api_router.include_router(health.router)
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
+api_router.include_router(templates.router, prefix="/templates", tags=["templates"])
 app.include_router(api_router)
 
 

--- a/backend/app/models/templates.py
+++ b/backend/app/models/templates.py
@@ -1,0 +1,21 @@
+"""Pydantic models describing document template generation."""
+from pydantic import BaseModel, Field
+
+from .documents import DocumentUsageMetrics
+
+
+class TemplateGenerationRequest(BaseModel):
+    """Incoming payload describing the desired template."""
+
+    prompt: str = Field(..., min_length=3, description="Opis celu dokumentu")
+    country: str = Field("PL", description="Kod kraju w formacie ISO 3166-1 alpha-2")
+
+
+class TemplateGenerationResponse(BaseModel):
+    """Response returned after generating a template."""
+
+    user_id: int
+    country: str
+    prompt: str
+    template: str
+    token_usage: DocumentUsageMetrics = Field(default_factory=DocumentUsageMetrics)

--- a/backend/app/services/inference.py
+++ b/backend/app/services/inference.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 import textwrap
-from typing import Iterable
+from typing import Callable, Iterable
 
 from ..core.config import get_settings
 from ..models.documents import DocumentDefinition, DocumentUsageMetrics, SectionSimplification
@@ -385,3 +385,111 @@ def _clean_meaning(meaning: str) -> str:
     cleaned = meaning.strip().rstrip(".;")
     cleaned = re.sub(r"\s+", " ", cleaned)
     return cleaned
+
+
+_SUPPORTED_TEMPLATE_BUILDERS: dict[str, Callable[[str], str]] = {}
+
+
+def generate_document_template(
+    prompt: str, country: str, use_cloud: bool | None = None
+) -> tuple[str, DocumentUsageMetrics]:
+    """Create a document template adjusted to the selected jurisdiction."""
+
+    cleaned_prompt = prompt.strip()
+    if not cleaned_prompt:
+        raise ValueError("Opis dokumentu nie może być pusty.")
+
+    normalised_country = country.strip().upper() or "PL"
+    builder = _SUPPORTED_TEMPLATE_BUILDERS.get(normalised_country)
+
+    if builder is None:
+        if normalised_country == "PL":
+            builder = _generate_template_pl_local
+            _SUPPORTED_TEMPLATE_BUILDERS[normalised_country] = builder
+        else:
+            raise ValueError(
+                "Obsługujemy obecnie jedynie generowanie wzorów dla Polski (PL)."
+            )
+
+    if _has_meaningful_text(cleaned_prompt) and _should_use_cloud(use_cloud):
+        client = get_openai_client()
+        try:
+            template, usage = client.generate_document_template(cleaned_prompt, normalised_country)
+            if template.strip():
+                return template.strip(), _usage_from_payload(usage)
+        except OpenAIClientError:
+            pass
+
+    return builder(cleaned_prompt), _zero_usage()
+
+
+def _generate_template_pl_local(prompt: str) -> str:
+    header = f"# Wzór dokumentu: {prompt}\n"
+    intro = (
+        "\n"
+        "Poniższa struktura opiera się na aktualnych wytycznych obowiązujących w Polsce "
+        "(stan na 2024 r.). Uzupełnij pola w nawiasach kwadratowych danymi właściwymi "
+        "dla konkretnej sprawy.\n"
+    )
+    sections = [
+        "## 1. Nagłówek\n- Miejscowość: [Miejscowość]\n- Data: [DD.MM.RRRR]\n",
+        (
+            "## 2. Strony umowy\n"
+            "- [Pełna nazwa/imię i nazwisko], [adres], [NIP/PESEL], reprezentowany przez [dane].\n"
+            "- [Pełna nazwa/imię i nazwisko], [adres], [NIP/PESEL], reprezentowany przez [dane].\n"
+        ),
+        (
+            "## 3. Podstawa prawna i definicje\n"
+            "- Oświadczenie o działaniu zgodnie z obowiązującymi przepisami prawa polskiego, w tym odpowiednimi ustawami sektorowymi.\n"
+            "- Definicje kluczowych pojęć wykorzystywanych w dokumencie.\n"
+        ),
+        (
+            "## 4. Przedmiot dokumentu\n"
+            "- Opis głównego celu: [szczegółowy opis zgodny z promptem].\n"
+            "- Zakres świadczeń/obowiązków stron.\n"
+        ),
+        (
+            "## 5. Oświadczenia i obowiązki stron\n"
+            "- Główne zobowiązania stron wraz z terminami wykonania.\n"
+            "- Wymogi zgodności z przepisami sektorowymi oraz RODO (jeżeli dotyczy).\n"
+        ),
+        (
+            "## 6. Postanowienia finansowe\n"
+            "- Warunki wynagrodzenia, sposób zapłaty, terminy fakturowania.\n"
+            "- Informacje o podatkach i kosztach dodatkowych.\n"
+        ),
+        (
+            "## 7. Terminy, wypowiedzenie i rozwiązanie\n"
+            "- Czas obowiązywania dokumentu.\n"
+            "- Procedury wypowiedzenia/rozwiązania wraz z okresem wypowiedzenia.\n"
+        ),
+        (
+            "## 8. Odpowiedzialność i sankcje\n"
+            "- Zakres odpowiedzialności stron.\n"
+            "- Kary umowne lub inne sankcje za naruszenia.\n"
+        ),
+        (
+            "## 9. Postanowienia dotyczące ochrony danych i poufności\n"
+            "- Klauzula poufności.\n"
+            "- Zasady przetwarzania danych osobowych zgodnie z RODO.\n"
+        ),
+        (
+            "## 10. Postanowienia końcowe\n"
+            "- Prawo właściwe i sąd właściwy.\n"
+            "- Klauzule dotyczące zmian dokumentu oraz komunikacji między stronami.\n"
+        ),
+        (
+            "## 11. Załączniki\n"
+            "- Lista załączników: [Załącznik nr 1], [Załącznik nr 2], ...\n"
+        ),
+        (
+            "## 12. Podpisy\n"
+            "- Podpis [Strona 1]\n"
+            "- Podpis [Strona 2]\n"
+        ),
+        (
+            "\n> **Uwaga:** Zweryfikuj dokument z aktualnymi przepisami branżowymi "
+            "i rozważ konsultację z radcą prawnym lub adwokatem przed zastosowaniem wzoru."
+        ),
+    ]
+    return header + intro + "\n".join(sections)

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -280,6 +280,43 @@ class OpenAIClient:
             raise OpenAIClientError("Brak treści odpowiedzi Q&A.")
         return {"answer": answer, "sources": sources}, usage
 
+    def generate_document_template(
+        self, prompt: str, country: str
+    ) -> tuple[str, dict[str, int]]:
+        logger.debug(
+            "Requesting OpenAI document template (country=%s, prompt_length=%d)",
+            country,
+            len(prompt),
+        )
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Jesteś prawniczym asystentem, który przygotowuje wzory dokumentów w "
+                    "oparciu o najnowsze wytyczne i praktykę danego kraju. Zawsze korzystaj z "
+                    "języka polskiego, zachowaj strukturę sekcji i dodaj wskazówki dotyczące "
+                    "zgodności z prawem."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Stwórz kompletny wzór dokumentu w formacie Markdown. "
+                    "Kraj: {country}. Kontekst: {prompt}. Uwzględnij aktualne wymagania "
+                    "prawne i rekomenduj, w jakich miejscach należy wpisać dane stron, "
+                    "podstawę prawną, obowiązki, postanowienia dotyczące ochrony danych, "
+                    "terminy oraz podpisy. Dodaj na końcu notatkę o konieczności weryfikacji "
+                    "z prawnikiem."
+                ).format(country=country, prompt=prompt)
+            },
+        ]
+        template, usage = self._complete(messages, max_tokens=1200)
+        logger.debug(
+            "Received OpenAI document template response (%s)",
+            self._summarise_content_for_log(template),
+        )
+        return template, usage
+
     def _complete(
         self,
         messages: list[dict[str, str]],

--- a/backend/tests/test_inference.py
+++ b/backend/tests/test_inference.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -59,4 +61,22 @@ def test_simplify_sections_skips_cloud_when_all_text_blank(monkeypatch):
     assert result == []
     assert usage.prompt_tokens == 0
     assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+
+
+def test_generate_document_template_requires_prompt():
+    with pytest.raises(ValueError):
+        inference.generate_document_template("  \n  ", "PL")
+
+
+def test_generate_document_template_local_builder(monkeypatch):
+    monkeypatch.setattr(inference, "_should_use_cloud", lambda use_cloud: False)
+
+    template, usage = inference.generate_document_template(
+        "Umowa o świadczenie usług IT", "pl"
+    )
+
+    assert "Wzór dokumentu" in template
+    assert "Umowa o świadczenie usług IT" in template
+    assert "Polsce" in template
     assert usage.total_tokens == 0

--- a/backend/tests/test_templates.py
+++ b/backend/tests/test_templates.py
@@ -1,0 +1,65 @@
+import importlib
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def template_client(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("PROSTE_PRAWO_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PROSTE_PRAWO_SESSION_SECRET_KEY", "secret")
+    monkeypatch.setenv("PROSTE_PRAWO_DISABLE_CLOUDFLARE_TURNSTILE", "1")
+    monkeypatch.setenv("PROSTE_PRAWO_ENABLE_CLOUD_LLM", "0")
+    monkeypatch.setenv("PROSTE_PRAWO_ENVIRONMENT", "test")
+
+    from app.core import config
+
+    config.get_settings.cache_clear()
+    importlib.reload(importlib.import_module("app.api.routes.templates"))
+    importlib.reload(importlib.import_module("app.api.routes.auth"))
+    main_module = importlib.reload(importlib.import_module("app.main"))
+    client = TestClient(main_module.app)
+    try:
+        yield client
+    finally:
+        client.close()
+        config.get_settings.cache_clear()
+
+
+def _register_user(client: TestClient, email: str) -> None:
+    response = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": "Secret123!", "turnstile_token": "ok"},
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["user"]["email"] == email
+
+
+def test_generate_template_returns_markdown(template_client):
+    _register_user(template_client, "template@example.com")
+
+    response = template_client.post(
+        "/api/templates/",
+        json={"prompt": "Umowa współpracy marketingowej", "country": "PL"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["country"] == "PL"
+    assert "Umowa współpracy marketingowej" in data["template"]
+    assert data["token_usage"]["total_tokens"] == 0
+
+
+def test_generate_template_rejects_unsupported_country(template_client):
+    _register_user(template_client, "country@example.com")
+
+    response = template_client.post(
+        "/api/templates/",
+        json={"prompt": "Kontrakt", "country": "DE"},
+    )
+    assert response.status_code == 400
+    assert "Polski" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- add FastAPI endpoint for generating legal document templates with authentication
- implement template generation helper with OpenAI support and Polish fallback
- cover new API and inference helpers with dedicated unit tests

## Testing
- pytest backend/tests/test_inference.py backend/tests/test_templates.py

------
https://chatgpt.com/codex/tasks/task_e_68e83eba53b88326a71bfb0c6519d305