### PR TITLE
Add automatic polling of dashboard document list

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,14 +1,21 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import UploadZone from '../components/UploadZone';
 import DocumentList from '../components/DocumentList';
 import { API_BASE_URL } from '../config';
 import type { DocumentListItem } from '../types';
 
+const POLLING_INTERVAL_MS = 5000;
+
 function DashboardPage() {
   const [documents, setDocuments] = useState<DocumentListItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const isLoadingRef = useRef(false);
 
   const loadDocuments = useCallback(async () => {
+    if (isLoadingRef.current) {
+      return;
+    }
+    isLoadingRef.current = true;
     setIsLoading(true);
     try {
       const response = await fetch(`${API_BASE_URL}/documents/`, {
@@ -23,12 +30,33 @@ function DashboardPage() {
       console.error(error);
     } finally {
       setIsLoading(false);
+      isLoadingRef.current = false;
     }
   }, []);
 
   useEffect(() => {
     void loadDocuments();
   }, [loadDocuments]);
+
+  useEffect(() => {
+    const shouldPoll = documents.some(
+      (document) => document.status === 'processing' || document.status === 'received'
+    );
+
+    if (!shouldPoll) {
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      if (!isLoadingRef.current) {
+        void loadDocuments();
+      }
+    }, POLLING_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [documents, loadDocuments]);
 
   return (
     <div className="dashboard">


### PR DESCRIPTION
## Summary
- start a periodic refresh whenever uploaded documents are still in processing or received states
- prevent overlapping dashboard fetches by tracking the in-flight request state

## Testing
- npm install *(fails: registry access returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e8463125e083268f4a176ac9ad987c