### PR TITLE
Add document template generator page and header link

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Link, NavLink, Route, Routes, useLocation } from 'react-router-dom';
 import DashboardPage from './pages/DashboardPage';
 import ReaderPage from './pages/ReaderPage';
 import ExportPage from './pages/ExportPage';
+import TemplateGeneratorPage from './pages/TemplateGeneratorPage';
 
 function App() {
   const location = useLocation();
@@ -12,15 +13,24 @@ function App() {
         <Link to="/" className="app-logo">
           ProstePrawo
         </Link>
-        <nav>
-          <NavLink to="/" className={({ isActive }) => (isActive && location.pathname === '/' ? 'active' : '')}>
-            Dashboard
+        <div className="app-header-actions">
+          <nav className="app-nav">
+            <NavLink to="/" className={({ isActive }) => (isActive && location.pathname === '/' ? 'active' : '')}>
+              Analizuj dokument
+            </NavLink>
+          </nav>
+          <NavLink
+            to="/templates"
+            className={({ isActive }) => `button header-primary-button${isActive ? ' active' : ''}`}
+          >
+            Generuj templatkę dokumentu
           </NavLink>
-        </nav>
+        </div>
       </header>
       <main className="app-main">
         <Routes>
           <Route path="/" element={<DashboardPage />} />
+          <Route path="/templates" element={<TemplateGeneratorPage />} />
           <Route path="/documents/:documentId" element={<ReaderPage />} />
           <Route path="/documents/:documentId/export" element={<ExportPage />} />
         </Routes>

--- a/frontend/src/pages/TemplateGeneratorPage.tsx
+++ b/frontend/src/pages/TemplateGeneratorPage.tsx
@@ -1,0 +1,168 @@
+import { FormEvent, useCallback, useMemo, useState } from 'react';
+import { API_BASE_URL } from '../config';
+import type { TemplateGenerationResponse } from '../types';
+
+const DEFAULT_COUNTRY = 'PL';
+
+function TemplateGeneratorPage() {
+  const [prompt, setPrompt] = useState('');
+  const [country, setCountry] = useState(DEFAULT_COUNTRY);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<TemplateGenerationResponse | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+
+  const isSubmitDisabled = useMemo(() => isSubmitting || prompt.trim().length < 3, [isSubmitting, prompt]);
+
+  const parseErrorMessage = useCallback(async (response: Response) => {
+    try {
+      const data = await response.json();
+      if (typeof data?.detail === 'string') {
+        return data.detail;
+      }
+      if (Array.isArray(data?.detail)) {
+        const messages = data.detail
+          .map((item: unknown) => {
+            if (item && typeof item === 'object' && 'msg' in item && typeof (item as { msg: unknown }).msg === 'string') {
+              return (item as { msg: string }).msg;
+            }
+            return null;
+          })
+          .filter((item): item is string => Boolean(item));
+        if (messages.length > 0) {
+          return messages.join(' ');
+        }
+      }
+    } catch (jsonError) {
+      console.warn('Nie udało się zdekodować odpowiedzi serwera.', jsonError);
+    }
+    return 'Nie udało się wygenerować wzoru dokumentu. Spróbuj ponownie później.';
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (isSubmitDisabled) {
+        return;
+      }
+
+      setIsSubmitting(true);
+      setError(null);
+      setCopyFeedback(null);
+
+      try {
+        const response = await fetch(`${API_BASE_URL}/templates/`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          credentials: 'include',
+          body: JSON.stringify({ prompt: prompt.trim(), country })
+        });
+
+        if (!response.ok) {
+          throw new Error(await parseErrorMessage(response));
+        }
+
+        const data: TemplateGenerationResponse = await response.json();
+        setResult(data);
+      } catch (submissionError) {
+        setResult(null);
+        setError(submissionError instanceof Error ? submissionError.message : 'Wystąpił nieoczekiwany błąd.');
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [country, isSubmitDisabled, parseErrorMessage, prompt]
+  );
+
+  const handleCopy = useCallback(async () => {
+    if (!result?.template) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(result.template);
+      setCopyFeedback('Skopiowano wzór dokumentu do schowka.');
+    } catch (copyError) {
+      console.error(copyError);
+      setCopyFeedback('Nie udało się skopiować treści.');
+    }
+  }, [result]);
+
+  return (
+    <div className="template-generator">
+      <section className="panel">
+        <div className="panel-header">
+          <div>
+            <h1>Generuj wzór dokumentu</h1>
+            <p className="panel-subtitle">Opisz, jakiego dokumentu potrzebujesz, aby otrzymać wstępną templatkę do dalszej edycji.</p>
+          </div>
+        </div>
+        <form className="template-form" onSubmit={handleSubmit}>
+          <label className="form-field" htmlFor="template-prompt">
+            Opis dokumentu
+            <textarea
+              id="template-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Przykład: Umowa współpracy marketingowej pomiędzy agencją a freelancerem w Polsce."
+              rows={8}
+            />
+          </label>
+          <div className="template-form-row">
+            <label className="select-field" htmlFor="template-country">
+              Jurysdykcja
+              <select id="template-country" value={country} onChange={(event) => setCountry(event.target.value)}>
+                <option value="PL">Polska (PL)</option>
+              </select>
+            </label>
+            <button type="submit" disabled={isSubmitDisabled}>
+              {isSubmitting ? 'Generowanie...' : 'Wygeneruj wzór'}
+            </button>
+          </div>
+          {error ? <p className="form-error">{error}</p> : null}
+          <p className="form-hint">System obecnie obsługuje generowanie wzorów dla polskiej jurysdykcji.</p>
+        </form>
+      </section>
+
+      {result ? (
+        <section className="panel template-result">
+          <div className="panel-header">
+            <div>
+              <h2>Twoja templatka dokumentu</h2>
+              <p className="panel-subtitle">Skopiuj i dopasuj treść do swoich potrzeb, uzupełniając oznaczone pola.</p>
+            </div>
+            <button type="button" className="button-link" onClick={handleCopy}>
+              Skopiuj treść
+            </button>
+          </div>
+          {copyFeedback ? <p className="status-message">{copyFeedback}</p> : null}
+          <article className="template-output">{result.template}</article>
+          <div className="token-usage" aria-live="polite">
+            <h3>Zużycie tokenów</h3>
+            <div className="token-usage-grid">
+              <div>
+                <span className="token-usage-label">Prompt</span>
+                <span className="token-usage-value">{result.token_usage.prompt_tokens}</span>
+              </div>
+              <div>
+                <span className="token-usage-label">Odpowiedź</span>
+                <span className="token-usage-value">{result.token_usage.completion_tokens}</span>
+              </div>
+              <div>
+                <span className="token-usage-label">Łącznie</span>
+                <span className="token-usage-value">{result.token_usage.total_tokens}</span>
+              </div>
+              <div>
+                <span className="token-usage-label">Koszt (USD)</span>
+                <span className="token-usage-value">{result.token_usage.cost_usd.toFixed(4)}</span>
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+export default TemplateGeneratorPage;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -36,6 +36,12 @@ body {
   color: inherit;
 }
 
+.app-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
 .app-header nav a {
   margin-left: 1rem;
   color: #d9e2ec;
@@ -43,10 +49,23 @@ body {
   font-weight: 500;
 }
 
+.app-header nav a:first-child {
+  margin-left: 0;
+}
+
 .app-header nav a.active,
 .app-header nav a:hover {
   color: #fff;
   text-decoration: underline;
+}
+
+.header-primary-button {
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+.header-primary-button.active {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25);
 }
 
 .app-main {
@@ -111,6 +130,111 @@ body {
   margin: 0.35rem 0 0;
   color: #64748b;
   font-size: 0.95rem;
+}
+
+.template-generator {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.template-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 160px;
+  border-radius: 12px;
+  border: 1px solid #d0d5dd;
+  padding: 0.75rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  font-family: inherit;
+  background-color: #fff;
+}
+
+.template-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.template-form-row .select-field {
+  flex: 1;
+}
+
+.template-form-row button {
+  min-width: 190px;
+}
+
+.form-error {
+  margin: 0;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.form-hint {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.template-result {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.template-output {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  white-space: pre-wrap;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #1e293b;
+}
+
+.token-usage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.token-usage h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.token-usage-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.token-usage-label {
+  display: block;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.token-usage-value {
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: #0f172a;
 }
 
 .cost-overview {
@@ -657,6 +781,15 @@ button:not(:disabled):hover,
 
   .reader-tools {
     flex-wrap: wrap;
+  }
+
+  .template-form-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .template-form-row button {
+    width: 100%;
   }
 
   .document-item {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,3 +46,11 @@ export interface SimplifiedResponse {
 export interface QaResponse {
   answer: string;
 }
+
+export interface TemplateGenerationResponse {
+  user_id: number;
+  country: string;
+  prompt: string;
+  template: string;
+  token_usage: TokenUsageMetrics;
+}


### PR DESCRIPTION
## Summary
- rename the dashboard navigation entry to "Analizuj dokument" and surface a header shortcut for generating templates
- add a dedicated template generator page that submits prompts to the backend and surfaces token usage with copy support
- extend shared styles and types to cover the new template workflow

## Testing
- not run (npm install blocked by 403 from registry.npmjs.org)


------
https://chatgpt.com/codex/tasks/task_e_68e852af45fc8326b36e2dc3f9c9e909